### PR TITLE
[EOC-86] Add autofocus functionality for forms

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/label-has-associated-control": 0,
     "jsx-a11y/label-has-for": 0,
+    "jsx-a11y/no-autofocus": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "key-spacing": "error",
     "keyword-spacing": ["error", { "before": true, "after": true }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,6 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/label-has-associated-control": 0,
     "jsx-a11y/label-has-for": 0,
-    "jsx-a11y/no-autofocus": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "key-spacing": "error",
     "keyword-spacing": ["error", { "before": true, "after": true }],

--- a/client/src/common/components/CreationForm.jsx
+++ b/client/src/common/components/CreationForm.jsx
@@ -18,10 +18,13 @@ class CreationForm extends PureComponent {
       description: defaultDescription || '',
       name: defaultName || ''
     };
+
+    this.input = React.createRef();
   }
 
   componentDidMount() {
     document.addEventListener('keydown', this.escapeListener);
+    this.input.current.focus();
   }
 
   componentWillUnmount() {
@@ -77,10 +80,10 @@ class CreationForm extends PureComponent {
           <div className="creation-form__body">
             <label className="creation-form__label">
               <input
-                autoFocus
                 className="creation-form__input primary-input"
                 onChange={this.handleValueChange}
                 placeholder="Name"
+                ref={this.input}
                 required={type === 'menu'}
                 type="text"
                 value={name}

--- a/client/src/common/components/CreationForm.jsx
+++ b/client/src/common/components/CreationForm.jsx
@@ -77,6 +77,7 @@ class CreationForm extends PureComponent {
           <div className="creation-form__body">
             <label className="creation-form__label">
               <input
+                autoFocus
                 className="creation-form__input primary-input"
                 onChange={this.handleValueChange}
                 placeholder="Name"

--- a/client/src/common/components/Form.jsx
+++ b/client/src/common/components/Form.jsx
@@ -50,6 +50,7 @@ class Form extends PureComponent {
         >
           <label className="form__label">
             <input
+              autoFocus
               className="form__input primary-input"
               onChange={this.handleNameChange}
               placeholder="Name"

--- a/client/src/common/components/Form.jsx
+++ b/client/src/common/components/Form.jsx
@@ -10,6 +10,12 @@ class Form extends PureComponent {
       description: defaultDescription || '',
       name: defaultName || ''
     };
+
+    this.input = React.createRef();
+  }
+
+  componentDidMount() {
+    this.input.current.focus();
   }
 
   handleNameChange = event => {
@@ -50,10 +56,10 @@ class Form extends PureComponent {
         >
           <label className="form__label">
             <input
-              autoFocus
               className="form__input primary-input"
               onChange={this.handleNameChange}
               placeholder="Name"
+              ref={this.input}
               type="text"
               value={name}
             />

--- a/client/src/modules/shopping-list/components/InputBar/InputBar.jsx
+++ b/client/src/modules/shopping-list/components/InputBar/InputBar.jsx
@@ -49,6 +49,7 @@ class InputBar extends Component {
         <div className="input-bar">
           <form className="input-bar__form" onSubmit={this.handleFormSubmit}>
             <input
+              autoFocus
               className="input-bar__input primary-input"
               onChange={this.handleNameChange}
               placeholder="What is missing?"

--- a/client/src/modules/shopping-list/components/InputBar/InputBar.jsx
+++ b/client/src/modules/shopping-list/components/InputBar/InputBar.jsx
@@ -8,9 +8,18 @@ import { RouterMatchPropType, UserPropType } from 'common/constants/propTypes';
 import { addItemToList } from './model/actions';
 
 class InputBar extends Component {
-  state = {
-    itemName: ''
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      itemName: ''
+    };
+    this.input = React.createRef();
+  }
+
+  componentDidMount() {
+    this.input.current.focus();
+  }
 
   handleNameChange = e => {
     this.setState({
@@ -49,10 +58,10 @@ class InputBar extends Component {
         <div className="input-bar">
           <form className="input-bar__form" onSubmit={this.handleFormSubmit}>
             <input
-              autoFocus
               className="input-bar__input primary-input"
               onChange={this.handleNameChange}
               placeholder="What is missing?"
+              ref={this.input}
               required
               type="text"
               value={itemName}


### PR DESCRIPTION
I have tried with `autoFocus` prop on input field and it works perfectly, but because this was so easy it made me curious if this the proper way to do it in React. 
Referring to react documentation and linked post from StackOverflow, the proper implementation is to use refs on inputs. 

Because react re-renders intelligently some parts of component independently `autoFocus` prop may not always work as expected.
[https://stackoverflow.com/questions/28889826/set-focus-on-input-after-render](url)
[https://reactjs.org/docs/refs-and-the-dom.html](url)