### PR TITLE
[HOTFIX]- Add hotfix for closing dialogs

### DIFF
--- a/client/src/modules/dashboard/index.jsx
+++ b/client/src/modules/dashboard/index.jsx
@@ -43,9 +43,11 @@ class Dashboard extends Component {
 
     switch (dialogContext) {
       case FormDialogContext.CREATE_COHORT:
-        return createCohort(title, description, id);
+        createCohort(title, description, id);
+        break;
       case FormDialogContext.CREATE_LIST:
-        return createList(title, description, id);
+        createList(title, description, id);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
Dialog boxes did not close due to a `return` to the switch statement. Changed to `break`