### PR TITLE
[EOC-118] Admin + purchaser => owner and member

### DIFF
--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -101,9 +101,9 @@ class Cohort extends PureComponent {
     return cohortDetails && cohortDetails.isArchived;
   };
 
-  checkIfAdmin = () => {
+  checkIfOwner = () => {
     const { cohortDetails } = this.props;
-    return cohortDetails && cohortDetails.isAdmin;
+    return cohortDetails && cohortDetails.isOwner;
   };
 
   handleDialogContext = context => () =>
@@ -148,7 +148,7 @@ class Cohort extends PureComponent {
     return (
       <Fragment>
         <Toolbar>
-          {!isArchived && this.checkIfAdmin() && (
+          {!isArchived && this.checkIfOwner() && (
             <Fragment>
               <ToolbarItem
                 mainIcon={<EditIcon />}

--- a/client/src/modules/cohort/model/actions.js
+++ b/client/src/modules/cohort/model/actions.js
@@ -122,12 +122,12 @@ const fetchArchivedCohortsMetaDataRequest = () => ({
   type: CohortActionTypes.FETCH_ARCHIVED_META_DATA_REQUEST
 });
 
-export const createCohort = (name, description, adminId) => dispatch => {
+export const createCohort = (name, description, ownerId) => dispatch => {
   dispatch(createCohortRequest());
   return postData(`${ENDPOINT_URL}/cohorts/create`, {
     name,
     description,
-    adminId
+    ownerId
   })
     .then(resp => resp.json())
     .then(json => dispatch(createCohortSuccess(json)))

--- a/client/src/modules/cohort/model/selectors.js
+++ b/client/src/modules/cohort/model/selectors.js
@@ -9,7 +9,7 @@ export const getCohortDetails = (state, cohortId) => {
     _filter(getCohorts(state), (_, key) => key === cohortId)
   );
   if (cohort) {
-    const { description, isAdmin, isArchived, name } = cohort;
-    return { description, isAdmin, isArchived, name };
+    const { description, isOwner, isArchived, name } = cohort;
+    return { description, isOwner, isArchived, name };
   }
 };

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -64,9 +64,9 @@ class List extends Component {
     return !list || (list && !list.isArchived);
   };
 
-  checkIfAdmin = () => {
+  checkIfOwner = () => {
     const { list } = this.props;
-    return list && list.isAdmin;
+    return list && list.isOwner;
   };
 
   handleDialogContext = context => () =>
@@ -103,7 +103,7 @@ class List extends Component {
               title="Go back to cohort"
             />
           )}
-          {!isArchived && this.checkIfAdmin() && (
+          {!isArchived && this.checkIfOwner() && (
             <Fragment>
               <ToolbarItem
                 mainIcon={<EditIcon />}

--- a/client/src/modules/list/model/actions.js
+++ b/client/src/modules/list/model/actions.js
@@ -137,12 +137,12 @@ export const fetchListData = listId => dispatch => {
 export const createList = (
   name,
   description,
-  adminId,
+  ownerId,
   cohortId
 ) => dispatch => {
   dispatch(createListRequest());
   return postData(`${ENDPOINT_URL}/lists/create`, {
-    adminId,
+    ownerId,
     cohortId,
     description,
     name

--- a/server/models/cohort.model.js
+++ b/server/models/cohort.model.js
@@ -5,7 +5,7 @@ const { ObjectId } = Schema.Types;
 
 const CohortSchema = new Schema(
   {
-    adminIds: [ObjectId],
+    ownerIds: [ObjectId],
     description: { type: String },
     isArchived: { type: Boolean, default: false },
     memberIds: [ObjectId],

--- a/server/models/list.model.js
+++ b/server/models/list.model.js
@@ -6,7 +6,7 @@ const ItemSchema = require('./item.model').schema;
 
 const ListSchema = new Schema(
   {
-    adminIds: [ObjectId],
+    ownerIds: [ObjectId],
     cohortId: {
       type: ObjectId,
       default: null
@@ -15,8 +15,7 @@ const ListSchema = new Schema(
     isArchived: { type: Boolean, default: false },
     items: [ItemSchema],
     name: { type: String, required: true },
-    ordererIds: [ObjectId],
-    purchaserIds: [ObjectId],
+    memberIds: [ObjectId],
     visibility: { type: String }
   },
   { timestamps: { createdAt: 'created_at' }, collection: 'lists' }


### PR DESCRIPTION
I was not sure what I should do with item schema. We have there authorId and purchaserId fields. Should we leave them as they are or change purchaserId to ownerId and auhorId to memberId?
In my opinion in 'items' case the most proper solution would be to leave purchaserId and change authorId to ordererId. These would be names reflecting the true meaning of these fields. Because of small difference between authorId and OrdererId I decided to leave item schema as it is: with authorId and PurchaserId. In all other cases I removed purchaserIds, changed ordererIds to memberIds and adminIds to ownerIds.