### PR TITLE
[EOC-111] Add preloader animation where needed

### DIFF
--- a/client/src/app/components/Layout/Layout.jsx
+++ b/client/src/app/components/Layout/Layout.jsx
@@ -53,13 +53,13 @@ export class Layout extends Component {
       <Fragment>
         <Notifications />
         <Switch>
+          <Route exact path="/" render={() => <Redirect to="/dashboard" />} />
           <Route component={Dashboard} path="/dashboard" />
           <Route component={Cohort} path="/cohort/:id(\w+)" />
           <Route component={List} path="/list/:id(\w+)" />
           <Route component={About} path="/about" />
           <Route component={PrivacyPolicy} path="/privacy-policy" />
           <Route component={Cohorts} path="/cohorts" />
-          <Route component={Dashboard} exact path="/" />
           <Route component={Page404} />
         </Switch>
         <Footer />

--- a/client/src/app/components/Layout/Layout.jsx
+++ b/client/src/app/components/Layout/Layout.jsx
@@ -53,7 +53,7 @@ export class Layout extends Component {
       <Fragment>
         <Notifications />
         <Switch>
-          <Route exact path="/" render={() => <Redirect to="/dashboard" />} />
+          <Redirect from="/" exact to="/dashboard" />
           <Route component={Dashboard} path="/dashboard" />
           <Route component={Cohort} path="/cohort/:id(\w+)" />
           <Route component={List} path="/list/:id(\w+)" />

--- a/client/src/app/styles/_buttons.scss
+++ b/client/src/app/styles/_buttons.scss
@@ -1,4 +1,5 @@
 .primary-button {
+  position: relative;
   font-weight: 600;
   color: $text-white;
   font-size: 10px;

--- a/client/src/common/components/ArchivedMessage.jsx
+++ b/client/src/common/components/ArchivedMessage.jsx
@@ -2,10 +2,12 @@ import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Dialog from 'common/components/Dialog';
+import Preloader from 'common/components/Preloader';
 
 class ArchivedMessage extends PureComponent {
   state = {
-    isDialogVisible: false
+    isDialogVisible: false,
+    pendingForDeletion: false
   };
 
   showDialog = () => this.setState({ isDialogVisible: true });
@@ -14,37 +16,56 @@ class ArchivedMessage extends PureComponent {
 
   handleDeletion = () => {
     const { onDelete } = this.props;
-    onDelete().catch(this.hideDialog);
+
+    this.setState({ pendingForDeletion: true }, () =>
+      onDelete().catch(() => {
+        this.setState({ pendingForDeletion: false });
+        this.hideDialog();
+      })
+    );
   };
 
   render() {
-    const { isDialogVisible } = this.state;
-    const { item, name, onRestore } = this.props;
+    const { isDialogVisible, pendingForDeletion } = this.state;
+    const { item, name, onRestore, pending, pendingMessage } = this.props;
 
     return (
       <Fragment>
         <div className="archived-message">
           <h1 className="archived-message__header">
-            {`The "${name}" ${item} was archived.`}
+            {pendingMessage || `The "${name}" ${item} was archived.`}
           </h1>
-          <button
-            className="archived-message__button primary-button"
-            onClick={this.showDialog}
-            type="button"
-          >
-            permanently delete
-          </button>
-          <button
-            className="archived-message__button primary-button"
-            type="button"
-            onClick={onRestore}
-          >
-            restore from archive
-          </button>
+          {pending && !isDialogVisible ? (
+            <div className="archived-message__body">
+              <Preloader />
+            </div>
+          ) : (
+            <div className="archived-message__body">
+              <button
+                className="archived-message__button primary-button"
+                onClick={this.showDialog}
+                type="button"
+              >
+                permanently delete
+              </button>
+              <button
+                className="archived-message__button primary-button"
+                type="button"
+                onClick={onRestore}
+              >
+                restore from archive
+              </button>
+            </div>
+          )}
         </div>
         {isDialogVisible && (
           <Dialog
-            title={`Do you really want to permanently delete the "${name}" ${item}?`}
+            title={
+              pendingForDeletion
+                ? `Deleting "${name}" ${item}...`
+                : `Do you really want to permanently delete the "${name}" ${item}?`
+            }
+            pending={pendingForDeletion}
             onCancel={this.hideDialog}
             onConfirm={this.handleDeletion}
           />
@@ -57,6 +78,8 @@ class ArchivedMessage extends PureComponent {
 ArchivedMessage.propTypes = {
   item: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  pending: PropTypes.bool.isRequired,
+  pendingMessage: PropTypes.string.isRequired,
 
   onDelete: PropTypes.func.isRequired,
   onRestore: PropTypes.func.isRequired

--- a/client/src/common/components/ArchivedMessage.jsx
+++ b/client/src/common/components/ArchivedMessage.jsx
@@ -17,20 +17,20 @@ class ArchivedMessage extends PureComponent {
   handleDeletion = () => {
     const { onDelete } = this.props;
 
-    this.setState({ pending: true }, () =>
-      onDelete().catch(() => {
-        this.setState({ pending: false });
-        this.hideDialog();
-      })
-    );
+    this.setState({ pending: true });
+
+    onDelete().catch(() => {
+      this.setState({ pending: false });
+      this.hideDialog();
+    });
   };
 
   handleRestoring = () => {
     const { onRestore } = this.props;
 
-    this.setState({ pending: true }, () =>
-      onRestore().catch(() => this.setState({ pending: false }))
-    );
+    this.setState({ pending: true });
+
+    onRestore().catch(() => this.setState({ pending: false }));
   };
 
   render() {
@@ -41,7 +41,7 @@ class ArchivedMessage extends PureComponent {
       <Fragment>
         <div className="archived-message">
           <h1 className="archived-message__header">
-            {pending
+            {pending && !isDialogVisible
               ? `Restoring "${name}" ${item}...`
               : `The "${name}" ${item} was archived.`}
           </h1>

--- a/client/src/common/components/ArchivedMessage.jsx
+++ b/client/src/common/components/ArchivedMessage.jsx
@@ -29,9 +29,7 @@ class ArchivedMessage extends PureComponent {
     const { onRestore } = this.props;
 
     this.setState({ pending: true }, () =>
-      onRestore()
-        .then(() => this.setState({ pending: false }))
-        .catch(() => this.setState({ pending: false }))
+      onRestore().catch(() => this.setState({ pending: false }))
     );
   };
 

--- a/client/src/common/components/ArchivedMessage.scss
+++ b/client/src/common/components/ArchivedMessage.scss
@@ -8,6 +8,10 @@
   padding: 20px 25px;
   box-shadow: 0 1px 3px rgba($shadow-color, 0.15);
 
+  &__body {
+    min-height: 80px;
+  }
+
   &__button {
     margin: 0 auto 16px;
 

--- a/client/src/common/components/CardItem.jsx
+++ b/client/src/common/components/CardItem.jsx
@@ -23,9 +23,7 @@ class CardItem extends PureComponent {
   handleFavClick = e => {
     const { onFavClick } = this.props;
     this.setState({ pending: true });
-    onFavClick(e)
-      .then(() => this.setState({ pending: false }))
-      .catch(() => this.setState({ pending: false }));
+    onFavClick(e).finally(() => this.setState({ pending: false }));
   };
 
   render() {

--- a/client/src/common/components/CardItem.jsx
+++ b/client/src/common/components/CardItem.jsx
@@ -59,6 +59,7 @@ class CardItem extends PureComponent {
         <p className="card-item__description">{description}</p>
         <button
           className="card-item__star"
+          disabled={pending}
           onClick={this.handleFavClick}
           type="button"
         >

--- a/client/src/common/components/CardItem.jsx
+++ b/client/src/common/components/CardItem.jsx
@@ -1,9 +1,13 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { RegularStarIcon, SolidStarIcon, LockIcon } from 'assets/images/icons';
 import { Routes } from 'common/constants/enums';
+import Preloader, {
+  PreloaderSize,
+  PreloaderTheme
+} from 'common/components/Preloader';
 
 export const CardColorType = {
   BROWN: 'card/BROWN',
@@ -11,48 +15,82 @@ export const CardColorType = {
   ORANGE: 'card/ORANGE'
 };
 
-const CardItem = ({
-  color,
-  description,
-  doneItemsCount,
-  isFavourite,
-  isPrivate,
-  membersCount,
-  name,
-  onCardClick,
-  onFavClick,
-  route,
-  unhandledItemsCount
-}) => (
-  <div
-    className={classNames('card-item', {
-      'card-item--orange': color === CardColorType.ORANGE,
-      'card-item--archived': color === CardColorType.ARCHIVED,
-      'card-item--brown': color === CardColorType.BROWN
-    })}
-    onClick={onCardClick}
-    role="figure"
-  >
-    <header className="card-item__header">
-      {isPrivate && <LockIcon />}
-      <h3 className="card-item__heading">{name}</h3>
-    </header>
-    <p className="card-item__description">{description}</p>
-    <button className="card-item__star" onClick={onFavClick} type="button">
-      {isFavourite ? <SolidStarIcon /> : <RegularStarIcon />}
-    </button>
-    <div className="card-item__data">
-      {route === Routes.LIST ? (
-        <Fragment>
-          <span>{`Done: ${doneItemsCount}`}</span>
-          <span>{`Unhandled: ${unhandledItemsCount}`}</span>
-        </Fragment>
-      ) : (
-        <span>{`Members: ${membersCount}`}</span>
-      )}
-    </div>
-  </div>
-);
+class CardItem extends PureComponent {
+  state = {
+    pending: false
+  };
+
+  handleFavClick = e => {
+    const { onFavClick } = this.props;
+    this.setState({ pending: true });
+    onFavClick(e)
+      .then(() => this.setState({ pending: false }))
+      .catch(() => this.setState({ pending: false }));
+  };
+
+  render() {
+    const {
+      color,
+      description,
+      doneItemsCount,
+      isFavourite,
+      isPrivate,
+      membersCount,
+      name,
+      onCardClick,
+      route,
+      unhandledItemsCount
+    } = this.props;
+
+    const { pending } = this.state;
+
+    return (
+      <div
+        className={classNames('card-item', {
+          'card-item--orange': color === CardColorType.ORANGE,
+          'card-item--archived': color === CardColorType.ARCHIVED,
+          'card-item--brown': color === CardColorType.BROWN
+        })}
+        onClick={onCardClick}
+        role="figure"
+      >
+        <header className="card-item__header">
+          {isPrivate && <LockIcon />}
+          <h3 className="card-item__heading">{name}</h3>
+        </header>
+        <p className="card-item__description">{description}</p>
+        <button
+          className="card-item__star"
+          onClick={this.handleFavClick}
+          type="button"
+        >
+          {pending ? (
+            <div className="card-item__preloader">
+              <Preloader
+                size={PreloaderSize.SMALL}
+                theme={PreloaderTheme.LIGHT}
+              />
+            </div>
+          ) : (
+            <Fragment>
+              {isFavourite ? <SolidStarIcon /> : <RegularStarIcon />}
+            </Fragment>
+          )}
+        </button>
+        <div className="card-item__data">
+          {route === Routes.LIST ? (
+            <Fragment>
+              <span>{`Done: ${doneItemsCount}`}</span>
+              <span>{`Unhandled: ${unhandledItemsCount}`}</span>
+            </Fragment>
+          ) : (
+            <span>{`Members: ${membersCount}`}</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
 
 export default CardItem;
 

--- a/client/src/common/components/CardItem.scss
+++ b/client/src/common/components/CardItem.scss
@@ -89,6 +89,12 @@
     }
   }
 
+  &__preloader {
+    position: relative;
+    right: 10px;
+    top: 10px;
+  }
+
   &__data {
     right: 8px;
     bottom: 8px;

--- a/client/src/common/components/Dialog.jsx
+++ b/client/src/common/components/Dialog.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import Overlay, { OverlayStyleType } from 'common/components/Overlay';
+import Preloader from 'common/components/Preloader';
 
 export const DialogContext = Object.freeze({
   ARCHIVE: 'dialog/ARCHIVE',
@@ -9,36 +10,45 @@ export const DialogContext = Object.freeze({
   UPDATE: 'dialog/UPDATE'
 });
 
-const Dialog = ({ children, onCancel, onConfirm, title }) => (
+const Dialog = ({ children, onCancel, onConfirm, pending, title }) => (
   <Fragment>
     <Overlay type={OverlayStyleType.MEDIUM} />
     <div className="dialog">
       <header className="dialog__header">
         <h2 className="dialog__heading">{title && title}</h2>
       </header>
-      {children && <div className="dialog__body">{children}</div>}
-      <div className="dialog__footer">
-        <button
-          className="dialog__button primary-button"
-          onClick={onConfirm}
-          type="button"
-        >
-          Confirm
-        </button>
-        <button
-          className="dialog__button primary-button"
-          onClick={onCancel}
-          type="button"
-        >
-          Cancel
-        </button>
-      </div>
+      {pending ? (
+        <div className="dialog__body">
+          <Preloader />
+        </div>
+      ) : (
+        <Fragment>
+          {children && <div className="dialog__body">{children}</div>}
+          <div className="dialog__footer">
+            <button
+              className="dialog__button primary-button"
+              onClick={onConfirm}
+              type="button"
+            >
+              Confirm
+            </button>
+            <button
+              className="dialog__button primary-button"
+              onClick={onCancel}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
+        </Fragment>
+      )}
     </div>
   </Fragment>
 );
 
 Dialog.propTypes = {
   children: PropTypes.node,
+  pending: PropTypes.bool,
   title: PropTypes.string,
 
   onCancel: PropTypes.func.isRequired,

--- a/client/src/common/components/Dialog.scss
+++ b/client/src/common/components/Dialog.scss
@@ -26,10 +26,12 @@
   }
 
   &__body {
+    position: relative;
     font-size: 13px;
     line-height: 1.2;
     color: $text-normal;
     padding: 10px 10px 0;
+    min-height: 100px;
   }
 
   &__footer {

--- a/client/src/common/components/FormDialog.jsx
+++ b/client/src/common/components/FormDialog.jsx
@@ -49,11 +49,17 @@ class FormDialog extends Component {
       defaultName,
       onCancel,
       onSelect,
+      pending,
       title
     } = this.props;
 
     return (
-      <Dialog onConfirm={this.handleConfirm} onCancel={onCancel} title={title}>
+      <Dialog
+        onConfirm={this.handleConfirm}
+        onCancel={onCancel}
+        pending={pending}
+        title={title}
+      >
         <Form
           defaultDescription={defaultDescription}
           defaultName={defaultName}
@@ -69,6 +75,7 @@ class FormDialog extends Component {
 FormDialog.propTypes = {
   defaultDescription: PropTypes.string,
   defaultName: PropTypes.string,
+  pending: PropTypes.bool.isRequired,
   title: PropTypes.string,
 
   onCancel: PropTypes.func,

--- a/client/src/common/components/GridList.jsx
+++ b/client/src/common/components/GridList.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import _map from 'lodash/map';
@@ -17,6 +17,7 @@ import {
   addCohortToFavourites,
   removeCohortFromFavourites
 } from 'modules/cohort/model/actions';
+import Preloader from 'common/components/Preloader';
 
 class GridList extends PureComponent {
   handleFavClick = (itemId, isFavourite) => event => {
@@ -54,6 +55,7 @@ class GridList extends PureComponent {
     const {
       color,
       icon,
+      isFetching,
       items,
       name,
       onAddNew,
@@ -68,38 +70,47 @@ class GridList extends PureComponent {
           {name}
         </h2>
         <div className="grid-list__body">
-          <ul className="grid-list__list">
-            {onAddNew && (
-              <li className="grid-list__item">
-                <button
-                  className="grid-list__button"
-                  onClick={onAddNew}
-                  type="button"
-                >
-                  <CardPlus />
-                </button>
-              </li>
-            )}
-            {_map(items, item => (
-              <li className="grid-list__item" key={item._id}>
-                <CardItem
-                  color={color}
-                  description={item.description}
-                  doneItemsCount={item.doneItemsCount}
-                  isFavourite={item.isFavourite}
-                  isPrivate={item.isPrivate}
-                  membersCount={item.membersCount}
-                  name={item.name}
-                  onCardClick={this.handleCardClick(route, item._id)}
-                  onFavClick={this.handleFavClick(item._id, item.isFavourite)}
-                  route={route}
-                  unhandledItemsCount={item.unhandledItemsCount}
-                />
-              </li>
-            ))}
-          </ul>
-          {_isEmpty(items) && (
-            <MessageBox message={placeholder} type={MessageType.INFO} />
+          {isFetching ? (
+            <Preloader />
+          ) : (
+            <Fragment>
+              <ul className="grid-list__list">
+                {onAddNew && (
+                  <li className="grid-list__item">
+                    <button
+                      className="grid-list__button"
+                      onClick={onAddNew}
+                      type="button"
+                    >
+                      <CardPlus />
+                    </button>
+                  </li>
+                )}
+                {_map(items, item => (
+                  <li className="grid-list__item" key={item._id}>
+                    <CardItem
+                      color={color}
+                      description={item.description}
+                      doneItemsCount={item.doneItemsCount}
+                      isFavourite={item.isFavourite}
+                      isPrivate={item.isPrivate}
+                      membersCount={item.membersCount}
+                      name={item.name}
+                      onCardClick={this.handleCardClick(route, item._id)}
+                      onFavClick={this.handleFavClick(
+                        item._id,
+                        item.isFavourite
+                      )}
+                      route={route}
+                      unhandledItemsCount={item.unhandledItemsCount}
+                    />
+                  </li>
+                ))}
+              </ul>
+              {_isEmpty(items) && (
+                <MessageBox message={placeholder} type={MessageType.INFO} />
+              )}
+            </Fragment>
           )}
         </div>
       </div>
@@ -113,6 +124,7 @@ GridList.propTypes = {
     push: PropTypes.func
   }),
   icon: PropTypes.node.isRequired,
+  isFetching: PropTypes.bool.isRequired,
   items: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,

--- a/client/src/common/components/GridList.jsx
+++ b/client/src/common/components/GridList.jsx
@@ -43,7 +43,7 @@ class GridList extends PureComponent {
       default:
         break;
     }
-    action(itemId);
+    return action(itemId);
   };
 
   handleCardClick = (route, itemId) => () => {

--- a/client/src/common/components/GridList.jsx
+++ b/client/src/common/components/GridList.jsx
@@ -55,10 +55,10 @@ class GridList extends PureComponent {
     const {
       color,
       icon,
-      isFetching,
       items,
       name,
       onAddNew,
+      pending,
       placeholder,
       route
     } = this.props;
@@ -70,7 +70,7 @@ class GridList extends PureComponent {
           {name}
         </h2>
         <div className="grid-list__body">
-          {isFetching ? (
+          {pending ? (
             <Preloader />
           ) : (
             <Fragment>
@@ -124,9 +124,9 @@ GridList.propTypes = {
     push: PropTypes.func
   }),
   icon: PropTypes.node.isRequired,
-  isFetching: PropTypes.bool.isRequired,
   items: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   name: PropTypes.string.isRequired,
+  pending: PropTypes.bool.isRequired,
   placeholder: PropTypes.string.isRequired,
   route: PropTypes.string.isRequired,
 

--- a/client/src/common/components/GridList.scss
+++ b/client/src/common/components/GridList.scss
@@ -25,7 +25,9 @@
   }
 
   &__body {
+    position: relative;
     padding: 16px 0 0;
+    min-height: 100px;
   }
 
   &__description {

--- a/client/src/common/components/Members/MembersBox.scss
+++ b/client/src/common/components/Members/MembersBox.scss
@@ -11,7 +11,6 @@
 
   &__list {
     display: flex;
-    align-items: center;
     flex-wrap: wrap;
     align-items: flex-start;
   }
@@ -28,6 +27,7 @@
   }
 
   &__member {
+    position: relative;
     align-items: center;
     background: $bg-color;
     border: 1px solid $border-light;

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -67,9 +67,7 @@ class MemberDetails extends PureComponent {
 
     this.setState({ pending: true });
 
-    action(id, userId, isOwner).catch(() => {
-      this.setState({ pending: false });
-    });
+    action(id, userId, isOwner).catch(() => this.setState({ pending: false }));
   };
 
   handleOwnerInfoVisibility = event => {

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -67,7 +67,9 @@ class MemberDetails extends PureComponent {
 
     this.setState({ pending: true });
 
-    action(id, userId, isOwner);
+    action(id, userId, isOwner).catch(() => {
+      this.setState({ pending: false });
+    });
   };
 
   handleOwnerInfoVisibility = event => {

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -66,17 +66,17 @@ class MemberDetails extends PureComponent {
     const action =
       route === Routes.COHORT ? removeCohortMember : removeListMember;
 
-    this.setState({ pending: true }, () =>
-      action(id, userId, isOwner)
-        .then(() => {
-          this.setState({ pending: false });
-          onClose();
-        })
-        .catch(() => {
-          this.setState({ pending: false });
-          onClose();
-        })
-    );
+    this.setState({ pending: true });
+
+    action(id, userId, isOwner)
+      .then(() => {
+        this.setState({ pending: false });
+        onClose();
+      })
+      .catch(() => {
+        this.setState({ pending: false });
+        onClose();
+      });
   };
 
   handleOwnerInfoVisibility = event => {
@@ -101,15 +101,11 @@ class MemberDetails extends PureComponent {
       _id: userId
     } = this.props;
 
-    this.setState({ pending: true }, () =>
-      action(id, userId, selectedRole)
-        .then(() => {
-          this.setState({ pending: false, selectedRole });
-        })
-        .catch(() => {
-          this.setState({ pending: false });
-        })
-    );
+    this.setState({ pending: true });
+
+    action(id, userId, selectedRole)
+      .then(() => this.setState({ pending: false, selectedRole }))
+      .catch(() => this.setState({ pending: false }));
   };
 
   handleChangingRoles = event => {

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -56,7 +56,6 @@ class MemberDetails extends PureComponent {
       match: {
         params: { id }
       },
-      onClose,
       removeCohortMember,
       removeListMember,
       route,
@@ -68,15 +67,7 @@ class MemberDetails extends PureComponent {
 
     this.setState({ pending: true });
 
-    action(id, userId, isOwner)
-      .then(() => {
-        this.setState({ pending: false });
-        onClose();
-      })
-      .catch(() => {
-        this.setState({ pending: false });
-        onClose();
-      });
+    action(id, userId, isOwner);
   };
 
   handleOwnerInfoVisibility = event => {
@@ -236,11 +227,15 @@ class MemberDetails extends PureComponent {
     const { isMemberInfoVisible, isOwnerInfoVisible, pending } = this.state;
     const { isGuest, isPrivate: privateList, route } = this.props;
 
-    return pending ? (
-      <div className="member-details__preloader">
-        <Preloader />
-      </div>
-    ) : (
+    if (pending) {
+      return (
+        <div className="member-details__preloader">
+          <Preloader />
+        </div>
+      );
+    }
+
+    return (
       <ul className="member-details__panel">
         <li className="member-details__option">
           {this.renderChangeRoleOption(UserRoles.OWNER, isOwnerInfoVisible)}

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -95,8 +95,8 @@ class MemberDetails extends PureComponent {
     this.setState({ pending: true });
 
     action(id, userId, selectedRole)
-      .then(() => this.setState({ pending: false, selectedRole }))
-      .catch(() => this.setState({ pending: false }));
+      .then(() => this.setState({ selectedRole }))
+      .finally(() => this.setState({ pending: false }));
   };
 
   handleChangingRoles = event => {

--- a/client/src/common/components/Members/components/MemberDetails.scss
+++ b/client/src/common/components/Members/components/MemberDetails.scss
@@ -89,6 +89,14 @@
     padding: 15px 0 0;
   }
 
+  &__preloader {
+    position: relative;
+    min-height: 80px;
+    display: flex;
+    align-items: center;
+    padding: 15px 0 0;
+  }
+
   &__option {
     display: flex;
     flex-wrap: wrap;

--- a/client/src/common/components/Members/components/MembersForm.jsx
+++ b/client/src/common/components/Members/components/MembersForm.jsx
@@ -85,8 +85,9 @@ class MembersForm extends PureComponent {
 }
 
 MembersForm.propTypes = {
-  onAddNew: PropTypes.func.isRequired,
-  pending: PropTypes.bool.isRequired
+  pending: PropTypes.bool.isRequired,
+
+  onAddNew: PropTypes.func.isRequired
 };
 
 export default MembersForm;

--- a/client/src/common/components/Members/components/MembersForm.jsx
+++ b/client/src/common/components/Members/components/MembersForm.jsx
@@ -66,6 +66,7 @@ class MembersForm extends PureComponent {
         />
         <button
           className="primary-button"
+          disabled={pending}
           onClick={this.handleAddNew}
           type="button"
         >

--- a/client/src/common/components/Members/components/MembersForm.jsx
+++ b/client/src/common/components/Members/components/MembersForm.jsx
@@ -1,6 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
+import Preloader, {
+  PreloaderSize,
+  PreloaderTheme
+} from 'common/components/Preloader';
+
 class MembersForm extends PureComponent {
   constructor(props) {
     super(props);
@@ -47,6 +52,8 @@ class MembersForm extends PureComponent {
 
   render() {
     const { inputValue } = this.state;
+    const { pending } = this.props;
+
     return (
       <form className="members-form" onSubmit={this.handleSubmit}>
         <input
@@ -57,19 +64,28 @@ class MembersForm extends PureComponent {
           type="email"
           value={inputValue}
         />
-        <input
+        <button
           className="primary-button"
           onClick={this.handleAddNew}
           type="button"
-          value="Add new"
-        />
+        >
+          {pending ? (
+            <Preloader
+              size={PreloaderSize.SMALL}
+              theme={PreloaderTheme.LIGHT}
+            />
+          ) : (
+            <span>Add new</span>
+          )}
+        </button>
       </form>
     );
   }
 }
 
 MembersForm.propTypes = {
-  onAddNew: PropTypes.func.isRequired
+  onAddNew: PropTypes.func.isRequired,
+  pending: PropTypes.bool.isRequired
 };
 
 export default MembersForm;

--- a/client/src/common/components/Members/components/MembersForm.scss
+++ b/client/src/common/components/Members/components/MembersForm.scss
@@ -4,4 +4,13 @@
   &__input {
     margin-right: 8px;
   }
+
+  .primary-button {
+    min-width: 80px;
+    overflow: hidden;
+  }
+
+  span {
+    white-space: nowrap;
+  }
 }

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -44,7 +44,7 @@ class MembersBox extends PureComponent {
 
     const action = route === Routes.COHORT ? addCohortMember : addListMember;
 
-    this.setState({ pending: true }, () => {
+    this.setState({ pending: true }, () =>
       action(id, email)
         .then(() => {
           this.setState({ pending: false });
@@ -53,8 +53,8 @@ class MembersBox extends PureComponent {
         .catch(() => {
           this.setState({ pending: false });
           this.hideForm();
-        });
-    });
+        })
+    );
   };
 
   renderMemberList = () => {

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -46,15 +46,10 @@ class MembersBox extends PureComponent {
 
     this.setState({ pending: true });
 
-    action(id, email)
-      .then(() => {
-        this.setState({ pending: false });
-        this.hideForm();
-      })
-      .catch(() => {
-        this.setState({ pending: false });
-        this.hideForm();
-      });
+    action(id, email).finally(() => {
+      this.setState({ pending: false });
+      this.hideForm();
+    });
   };
 
   renderMemberList = () => {

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -44,17 +44,17 @@ class MembersBox extends PureComponent {
 
     const action = route === Routes.COHORT ? addCohortMember : addListMember;
 
-    this.setState({ pending: true }, () =>
-      action(id, email)
-        .then(() => {
-          this.setState({ pending: false });
-          this.hideForm();
-        })
-        .catch(() => {
-          this.setState({ pending: false });
-          this.hideForm();
-        })
-    );
+    this.setState({ pending: true });
+
+    action(id, email)
+      .then(() => {
+        this.setState({ pending: false });
+        this.hideForm();
+      })
+      .catch(() => {
+        this.setState({ pending: false });
+        this.hideForm();
+      });
   };
 
   renderMemberList = () => {

--- a/client/src/common/components/Preloader.jsx
+++ b/client/src/common/components/Preloader.jsx
@@ -7,16 +7,35 @@ export const PreloaderTheme = {
   LIGHT: 'preloader/LIGHT'
 };
 
-const Preloader = ({ message, theme = PreloaderTheme.DARK }) => (
+export const PreloaderSize = {
+  BIG: 'preloader/BIG',
+  SMALL: 'preloader/SMALL'
+};
+
+const Preloader = ({
+  message,
+  size = PreloaderSize.BIG,
+  theme = PreloaderTheme.DARK
+}) => (
   <div className="preloader">
-    <div className="preloader__spinner">
+    <div
+      className={classNames('preloader__spinner', {
+        'preloader__spinner--small': size === PreloaderSize.SMALL,
+        'preloader__spinner--big': size === PreloaderSize.BIG
+      })}
+    >
       <div
         className={classNames('preloader__shape1', {
-          'preloader__shape--dark': theme === PreloaderTheme.DARK,
-          'preloader__shape--light': theme === PreloaderTheme.LIGHT
+          'preloader__shape1--dark': theme === PreloaderTheme.DARK,
+          'preloader__shape1--light': theme === PreloaderTheme.LIGHT
         })}
       />
-      <div className="preloader__shape2" />
+      <div
+        className={classNames('preloader__shape2', {
+          'preloader__shape2--dark': theme === PreloaderTheme.DARK,
+          'preloader__shape2--light': theme === PreloaderTheme.LIGHT
+        })}
+      />
     </div>
     <span className="preloader__text">{message}</span>
   </div>
@@ -24,6 +43,7 @@ const Preloader = ({ message, theme = PreloaderTheme.DARK }) => (
 
 Preloader.propTypes = {
   message: PropTypes.string,
+  size: PropTypes.string,
   theme: PropTypes.string
 };
 

--- a/client/src/common/components/Preloader.jsx
+++ b/client/src/common/components/Preloader.jsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Preloader = ({ message }) => (
+export const PreloaderTheme = {
+  DARK: 'preloader/DARK',
+  LIGHT: 'preloader/LIGHT'
+};
+
+const Preloader = ({ message, theme = PreloaderTheme.DARK }) => (
   <div className="preloader">
     <div className="preloader__spinner">
-      <div className="preloader__shape1" />
+      <div
+        className={classNames('preloader__shape1', {
+          'preloader__shape--dark': theme === PreloaderTheme.DARK,
+          'preloader__shape--light': theme === PreloaderTheme.LIGHT
+        })}
+      />
       <div className="preloader__shape2" />
     </div>
     <span className="preloader__text">{message}</span>
@@ -12,7 +23,8 @@ const Preloader = ({ message }) => (
 );
 
 Preloader.propTypes = {
-  message: PropTypes.string
+  message: PropTypes.string,
+  theme: PropTypes.string
 };
 
 export default Preloader;

--- a/client/src/common/components/Preloader.scss
+++ b/client/src/common/components/Preloader.scss
@@ -10,11 +10,16 @@
   transform: translate(-50%, -50%);
 
   &__spinner {
-    width: 40px;
-    height: 40px;
-
     position: relative;
-    margin: 20px auto;
+    &--big {
+      width: 40px;
+      height: 40px;
+    }
+
+    &--small {
+      width: 25px;
+      height: 25px;
+    }
   }
 
   &__shape1,
@@ -22,13 +27,20 @@
     width: 100%;
     height: 100%;
     border-radius: 50%;
-    background-color: $dark-orange;
     opacity: 0.6;
     position: absolute;
     top: 0;
     left: 0;
 
     animation: bounce 2s infinite ease-in-out;
+
+    &--dark {
+      background-color: $dark-orange;
+    }
+
+    &--light {
+      background-color: $bg-color;
+    }
   }
 
   &__shape2 {

--- a/client/src/common/components/Preloader.scss
+++ b/client/src/common/components/Preloader.scss
@@ -2,11 +2,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
   z-index: 4;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 
   &__spinner {
     width: 40px;
@@ -21,7 +22,7 @@
     width: 100%;
     height: 100%;
     border-radius: 50%;
-    background-color: $brand-color;
+    background-color: $dark-orange;
     opacity: 0.6;
     position: absolute;
     top: 0;

--- a/client/src/modules/cohort/components/ArchivedCohort.jsx
+++ b/client/src/modules/cohort/components/ArchivedCohort.jsx
@@ -5,28 +5,15 @@ import PropTypes from 'prop-types';
 import { deleteCohort, restoreCohort } from 'modules/cohort/model/actions';
 import { fetchListsMetaData } from 'modules/list/model/actions';
 import ArchivedMessage from 'common/components/ArchivedMessage';
+import { noOp } from 'common/utils/noOp';
 
 class ArchivedCohort extends PureComponent {
-  constructor(props) {
-    super(props);
-
-    const { pending } = this.props;
-    this.state = {
-      pending,
-      pendingMessage: ''
-    };
-  }
-
   handleCohortRestoring = cohortId => () => {
-    const { fetchListsMetaData, name, restoreCohort } = this.props;
+    const { fetchListsMetaData, restoreCohort } = this.props;
 
-    this.setState(
-      { pending: true, pendingMessage: `Restoring "${name}" cohort...` },
-      () =>
-        restoreCohort(cohortId)
-          .then(() => fetchListsMetaData(cohortId))
-          .catch(() => this.setState({ pending: false, pendingMessage: '' }))
-    );
+    return restoreCohort(cohortId)
+      .then(() => fetchListsMetaData(cohortId))
+      .catch(noOp);
   };
 
   handleCohortDeletion = cohortId => () => {
@@ -37,14 +24,10 @@ class ArchivedCohort extends PureComponent {
   render() {
     const { cohortId, name } = this.props;
 
-    const { pending, pendingMessage } = this.state;
-
     return (
       <ArchivedMessage
         item="cohort"
         name={name}
-        pending={pending}
-        pendingMessage={pendingMessage}
         onDelete={this.handleCohortDeletion(cohortId)}
         onRestore={this.handleCohortRestoring(cohortId)}
       />
@@ -55,7 +38,6 @@ class ArchivedCohort extends PureComponent {
 ArchivedCohort.propTypes = {
   cohortId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  pending: PropTypes.bool.isRequired,
 
   deleteCohort: PropTypes.func.isRequired,
   fetchListsMetaData: PropTypes.func.isRequired,

--- a/client/src/modules/cohort/components/ArchivedCohort.jsx
+++ b/client/src/modules/cohort/components/ArchivedCohort.jsx
@@ -5,15 +5,12 @@ import PropTypes from 'prop-types';
 import { deleteCohort, restoreCohort } from 'modules/cohort/model/actions';
 import { fetchListsMetaData } from 'modules/list/model/actions';
 import ArchivedMessage from 'common/components/ArchivedMessage';
-import { noOp } from 'common/utils/noOp';
 
 class ArchivedCohort extends PureComponent {
   handleCohortRestoring = cohortId => () => {
     const { fetchListsMetaData, restoreCohort } = this.props;
 
-    return restoreCohort(cohortId)
-      .then(() => fetchListsMetaData(cohortId))
-      .catch(noOp);
+    return restoreCohort(cohortId).then(() => fetchListsMetaData(cohortId));
   };
 
   handleCohortDeletion = cohortId => () => {

--- a/client/src/modules/cohort/components/CohortHeader.jsx
+++ b/client/src/modules/cohort/components/CohortHeader.jsx
@@ -107,21 +107,21 @@ class CohortHeader extends PureComponent {
     }
 
     if (nameToUpdate.length >= 1) {
-      this.setState({ pendingForName: true }, () => {
-        updateCohort(id, { name })
-          .then(() =>
-            this.setState({
-              isNameInputVisible: false,
-              pendingForName: false
-            })
-          )
-          .catch(() =>
-            this.setState({
-              isNameInputVisible: false,
-              pendingForName: false
-            })
-          );
-      });
+      this.setState({ pendingForName: true });
+
+      updateCohort(id, { name })
+        .then(() =>
+          this.setState({
+            isNameInputVisible: false,
+            pendingForName: false
+          })
+        )
+        .catch(() =>
+          this.setState({
+            isNameInputVisible: false,
+            pendingForName: false
+          })
+        );
     }
   };
 
@@ -146,21 +146,21 @@ class CohortHeader extends PureComponent {
 
     const updatedDescription = _isEmpty(_trim(description)) ? '' : description;
 
-    this.setState(
-      { isDescriptionTextareaVisible: false, pendingForDescription: true },
-      () => {
-        updateCohort(id, { description: updatedDescription })
-          .then(() =>
-            this.setState({
-              description: updatedDescription,
-              pendingForDescription: false
-            })
-          )
-          .catch(() => {
-            this.setState({ pendingForDescription: false });
-          });
-      }
-    );
+    this.setState({
+      isDescriptionTextareaVisible: false,
+      pendingForDescription: true
+    });
+
+    updateCohort(id, { description: updatedDescription })
+      .then(() =>
+        this.setState({
+          description: updatedDescription,
+          pendingForDescription: false
+        })
+      )
+      .catch(() => {
+        this.setState({ pendingForDescription: false });
+      });
   };
 
   renderDescription = () => {

--- a/client/src/modules/cohort/components/CohortHeader.jsx
+++ b/client/src/modules/cohort/components/CohortHeader.jsx
@@ -109,19 +109,12 @@ class CohortHeader extends PureComponent {
     if (nameToUpdate.length >= 1) {
       this.setState({ pendingForName: true });
 
-      updateCohort(id, { name })
-        .then(() =>
-          this.setState({
-            isNameInputVisible: false,
-            pendingForName: false
-          })
-        )
-        .catch(() =>
-          this.setState({
-            isNameInputVisible: false,
-            pendingForName: false
-          })
-        );
+      updateCohort(id, { name }).finally(() =>
+        this.setState({
+          isNameInputVisible: false,
+          pendingForName: false
+        })
+      );
     }
   };
 
@@ -158,9 +151,7 @@ class CohortHeader extends PureComponent {
           pendingForDescription: false
         })
       )
-      .catch(() => {
-        this.setState({ pendingForDescription: false });
-      });
+      .catch(() => this.setState({ pendingForDescription: false }));
   };
 
   renderDescription = () => {
@@ -170,9 +161,9 @@ class CohortHeader extends PureComponent {
       pendingForDescription
     } = this.state;
 
-    return pendingForDescription ? (
-      <Preloader size={PreloaderSize.SMALL} />
-    ) : (
+    if (pendingForDescription) return <Preloader size={PreloaderSize.SMALL} />;
+
+    return (
       <Fragment>
         {isDescriptionTextareaVisible ? (
           <DescriptionTextarea
@@ -209,9 +200,9 @@ class CohortHeader extends PureComponent {
   renderName = () => {
     const { name, isNameInputVisible, pendingForName } = this.state;
 
-    return pendingForName ? (
-      <Preloader size={PreloaderSize.SMALL} />
-    ) : (
+    if (pendingForName) return <Preloader size={PreloaderSize.SMALL} />;
+
+    return (
       <Fragment>
         {isNameInputVisible ? (
           <NameInput

--- a/client/src/modules/cohort/components/CohortHeader.jsx
+++ b/client/src/modules/cohort/components/CohortHeader.jsx
@@ -161,37 +161,35 @@ class CohortHeader extends PureComponent {
       pendingForDescription
     } = this.state;
 
-    if (pendingForDescription) return <Preloader size={PreloaderSize.SMALL} />;
+    if (pendingForDescription) {
+      return <Preloader size={PreloaderSize.SMALL} />;
+    }
 
-    return (
+    return isDescriptionTextareaVisible ? (
+      <DescriptionTextarea
+        description={description}
+        onClick={this.handleClick}
+        onDescriptionChange={this.handleDescriptionChange}
+        onKeyPress={this.handleKeyPress}
+      />
+    ) : (
       <Fragment>
-        {isDescriptionTextareaVisible ? (
-          <DescriptionTextarea
-            description={description}
-            onClick={this.handleClick}
-            onDescriptionChange={this.handleDescriptionChange}
-            onKeyPress={this.handleKeyPress}
-          />
+        {description ? (
+          <p
+            className="cohort-header__description"
+            data-id="description"
+            onClick={this.handleDescriptionTextareaVisibility}
+          >
+            {description}
+          </p>
         ) : (
-          <Fragment>
-            {description ? (
-              <p
-                className="cohort-header__description"
-                data-id="description"
-                onClick={this.handleDescriptionTextareaVisibility}
-              >
-                {description}
-              </p>
-            ) : (
-              <button
-                className="cohort-header__button link-button"
-                onClick={this.handleDescriptionTextareaVisibility}
-                type="button"
-              >
-                Add description
-              </button>
-            )}
-          </Fragment>
+          <button
+            className="cohort-header__button link-button"
+            onClick={this.handleDescriptionTextareaVisibility}
+            type="button"
+          >
+            Add description
+          </button>
         )}
       </Fragment>
     );
@@ -200,26 +198,24 @@ class CohortHeader extends PureComponent {
   renderName = () => {
     const { name, isNameInputVisible, pendingForName } = this.state;
 
-    if (pendingForName) return <Preloader size={PreloaderSize.SMALL} />;
+    if (pendingForName) {
+      return <Preloader size={PreloaderSize.SMALL} />;
+    }
 
-    return (
-      <Fragment>
-        {isNameInputVisible ? (
-          <NameInput
-            name={name}
-            onClick={this.handleClick}
-            onKeyPress={this.handleKeyPress}
-            onNameChange={this.handleNameChange}
-          />
-        ) : (
-          <h1
-            className="cohort-header__heading"
-            onClick={this.handleNameInputVisibility}
-          >
-            {name}
-          </h1>
-        )}
-      </Fragment>
+    return isNameInputVisible ? (
+      <NameInput
+        name={name}
+        onClick={this.handleClick}
+        onKeyPress={this.handleKeyPress}
+        onNameChange={this.handleNameChange}
+      />
+    ) : (
+      <h1
+        className="cohort-header__heading"
+        onClick={this.handleNameInputVisibility}
+      >
+        {name}
+      </h1>
     );
   };
 

--- a/client/src/modules/cohort/components/CohortHeader.scss
+++ b/client/src/modules/cohort/components/CohortHeader.scss
@@ -11,8 +11,14 @@
   }
 
   &__top {
+    position: relative;
     display: flex;
     align-items: center;
+  }
+
+  &__bottom {
+    position: relative;
+    min-height: 35px;
   }
 
   &__description {

--- a/client/src/modules/cohort/components/Cohorts.jsx
+++ b/client/src/modules/cohort/components/Cohorts.jsx
@@ -35,9 +35,9 @@ class Cohorts extends Component {
 
     this.setState({ pendingForCohorts: true });
 
-    fetchCohortsMetaData()
-      .then(() => this.setState({ pendingForCohorts: false }))
-      .catch(() => this.setState({ pendingForCohorts: false }));
+    fetchCohortsMetaData().finally(() =>
+      this.setState({ pendingForCohorts: false })
+    );
   }
 
   handleDialogVisibility = () =>
@@ -54,15 +54,10 @@ class Cohorts extends Component {
 
     this.setState({ pendingForCohortCreation: true });
 
-    createCohort(data)
-      .then(() => {
-        this.setState({ pendingForCohortCreation: false });
-        this.handleDialogVisibility();
-      })
-      .catch(() => {
-        this.setState({ pendingForCohortCreation: false });
-        this.handleDialogVisibility();
-      });
+    createCohort(data).finally(() => {
+      this.setState({ pendingForCohortCreation: false });
+      this.handleDialogVisibility();
+    });
   };
 
   handleArchivedCohortsVisibility = () =>
@@ -83,9 +78,9 @@ class Cohorts extends Component {
     if (areArchivedCohortsVisible) {
       this.setState({ pendingForArchivedCohorts: true });
 
-      fetchArchivedCohortsMetaData()
-        .then(() => this.setState({ pendingForArchivedCohorts: false }))
-        .catch(() => this.setState({ pendingForArchivedCohorts: false }));
+      fetchArchivedCohortsMetaData().finally(() =>
+        this.setState({ pendingForArchivedCohorts: false })
+      );
     } else {
       removeArchivedCohortsMetaData();
     }

--- a/client/src/modules/cohort/components/Cohorts.jsx
+++ b/client/src/modules/cohort/components/Cohorts.jsx
@@ -34,11 +34,11 @@ class Cohorts extends Component {
     const { fetchCohortsMetaData } = this.props;
 
     fetchCohortsMetaData();
-    this.setState({ pendingForCohorts: true }, () => {
-      fetchCohortsMetaData()
-        .then(() => this.setState({ pendingForCohorts: false }))
-        .catch(() => this.setState({ pendingForCohorts: false }));
-    });
+    this.setState({ pendingForCohorts: true });
+
+    fetchCohortsMetaData()
+      .then(() => this.setState({ pendingForCohorts: false }))
+      .catch(() => this.setState({ pendingForCohorts: false }));
   }
 
   handleDialogVisibility = () =>
@@ -53,17 +53,17 @@ class Cohorts extends Component {
     } = this.props;
     const data = { description, userId, name };
 
-    this.setState({ pendingForCohortCreation: true }, () => {
-      createCohort(data)
-        .then(() => {
-          this.setState({ pendingForCohortCreation: false });
-          this.handleDialogVisibility();
-        })
-        .catch(() => {
-          this.setState({ pendingForCohortCreation: false });
-          this.handleDialogVisibility();
-        });
-    });
+    this.setState({ pendingForCohortCreation: true });
+
+    createCohort(data)
+      .then(() => {
+        this.setState({ pendingForCohortCreation: false });
+        this.handleDialogVisibility();
+      })
+      .catch(() => {
+        this.setState({ pendingForCohortCreation: false });
+        this.handleDialogVisibility();
+      });
   };
 
   handleArchivedCohortsVisibility = () =>
@@ -82,11 +82,11 @@ class Cohorts extends Component {
     } = this.props;
 
     if (areArchivedCohortsVisible) {
-      this.setState({ pendingForArchivedCohorts: true }, () => {
-        fetchArchivedCohortsMetaData()
-          .then(() => this.setState({ pendingForArchivedCohorts: false }))
-          .catch(() => this.setState({ pendingForArchivedCohorts: false }));
-      });
+      this.setState({ pendingForArchivedCohorts: true });
+
+      fetchArchivedCohortsMetaData()
+        .then(() => this.setState({ pendingForArchivedCohorts: false }))
+        .catch(() => this.setState({ pendingForArchivedCohorts: false }));
     } else {
       removeArchivedCohortsMetaData();
     }

--- a/client/src/modules/cohort/components/Cohorts.jsx
+++ b/client/src/modules/cohort/components/Cohorts.jsx
@@ -24,13 +24,21 @@ import { Routes } from 'common/constants/enums';
 class Cohorts extends Component {
   state = {
     areArchivedCohortsVisible: false,
-    isDialogVisible: false
+    isDialogVisible: false,
+    pendingForCohortCreation: false,
+    pendingForCohorts: false,
+    pendingForArchivedCohorts: false
   };
 
   componentDidMount() {
     const { fetchCohortsMetaData } = this.props;
 
     fetchCohortsMetaData();
+    this.setState({ pendingForCohorts: true }, () => {
+      fetchCohortsMetaData()
+        .then(() => this.setState({ pendingForCohorts: false }))
+        .catch(() => this.setState({ pendingForCohorts: false }));
+    });
   }
 
   handleDialogVisibility = () =>
@@ -44,8 +52,18 @@ class Cohorts extends Component {
       currentUser: { id: userId }
     } = this.props;
     const data = { description, userId, name };
-    createCohort(data);
-    this.handleDialogVisibility();
+
+    this.setState({ pendingForCohortCreation: true }, () => {
+      createCohort(data)
+        .then(() => {
+          this.setState({ pendingForCohortCreation: false });
+          this.handleDialogVisibility();
+        })
+        .catch(() => {
+          this.setState({ pendingForCohortCreation: false });
+          this.handleDialogVisibility();
+        });
+    });
   };
 
   handleArchivedCohortsVisibility = () =>
@@ -62,15 +80,27 @@ class Cohorts extends Component {
       fetchArchivedCohortsMetaData,
       removeArchivedCohortsMetaData
     } = this.props;
-    const action = areArchivedCohortsVisible
-      ? fetchArchivedCohortsMetaData
-      : removeArchivedCohortsMetaData;
-    action();
+
+    if (areArchivedCohortsVisible) {
+      this.setState({ pendingForArchivedCohorts: true }, () => {
+        fetchArchivedCohortsMetaData()
+          .then(() => this.setState({ pendingForArchivedCohorts: false }))
+          .catch(() => this.setState({ pendingForArchivedCohorts: false }));
+      });
+    } else {
+      removeArchivedCohortsMetaData();
+    }
   };
 
   render() {
     const { archivedCohorts, cohorts } = this.props;
-    const { areArchivedCohortsVisible, isDialogVisible } = this.state;
+    const {
+      areArchivedCohortsVisible,
+      isDialogVisible,
+      pendingForArchivedCohorts,
+      pendingForCohortCreation,
+      pendingForCohorts
+    } = this.state;
 
     return (
       <Fragment>
@@ -83,6 +113,7 @@ class Cohorts extends Component {
               items={cohorts}
               name="Cohorts"
               onAddNew={this.handleDialogVisibility}
+              pending={pendingForCohorts}
               placeholder="There are no cohorts yet!"
               route={Routes.COHORT}
             />
@@ -101,6 +132,7 @@ class Cohorts extends Component {
                 icon={<CohortIcon />}
                 items={archivedCohorts}
                 name="Archived cohorts"
+                pending={pendingForArchivedCohorts}
                 placeholder="You have no archived cohorts!"
                 route={Routes.COHORT}
               />
@@ -111,7 +143,8 @@ class Cohorts extends Component {
           <FormDialog
             onCancel={this.handleDialogVisibility}
             onConfirm={this.handleConfirm}
-            title="Add new cohort"
+            pending={pendingForCohortCreation}
+            title={`${pendingForCohortCreation ? 'Adding' : 'Add'} new cohort`}
           />
         )}
       </Fragment>

--- a/client/src/modules/cohort/components/Cohorts.jsx
+++ b/client/src/modules/cohort/components/Cohorts.jsx
@@ -33,7 +33,6 @@ class Cohorts extends Component {
   componentDidMount() {
     const { fetchCohortsMetaData } = this.props;
 
-    fetchCohortsMetaData();
     this.setState({ pendingForCohorts: true });
 
     fetchCohortsMetaData()

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -61,8 +61,7 @@ class Cohort extends PureComponent {
           return fetchListsMetaData(id);
         }
       })
-      .then(() => this.setState({ pendingForDetails: false }))
-      .catch(() => this.setState({ pendingForDetails: false }));
+      .finally(() => this.setState({ pendingForDetails: false }));
   };
 
   handleListCreation = (name, description) => {
@@ -79,15 +78,10 @@ class Cohort extends PureComponent {
 
     this.setState({ pendingForListCreation: true });
 
-    createList(data)
-      .then(() => {
-        this.setState({ pendingForListCreation: false });
-        this.hideDialog();
-      })
-      .catch(() => {
-        this.setState({ pendingForListCreation: false });
-        this.hideDialog();
-      });
+    createList(data).finally(() => {
+      this.setState({ pendingForListCreation: false });
+      this.hideDialog();
+    });
   };
 
   handleCohortArchivization = cohortId => () => {
@@ -95,15 +89,10 @@ class Cohort extends PureComponent {
 
     this.setState({ pendingForCohortArchivization: true });
 
-    archiveCohort(cohortId)
-      .then(() => {
-        this.setState({ pendingForCohortArchivization: false });
-        this.hideDialog();
-      })
-      .catch(() => {
-        this.setState({ pendingForCohortArchivization: false });
-        this.hideDialog();
-      });
+    archiveCohort(cohortId).finally(() => {
+      this.setState({ pendingForCohortArchivization: false });
+      this.hideDialog();
+    });
   };
 
   checkIfArchived = () => {
@@ -142,9 +131,9 @@ class Cohort extends PureComponent {
     if (areArchivedListsVisible) {
       this.setState({ pendingForArchivedLists: true });
 
-      fetchArchivedListsMetaData()
-        .then(() => this.setState({ pendingForArchivedLists: false }))
-        .catch(() => this.setState({ pendingForArchivedLists: false }));
+      fetchArchivedListsMetaData().finally(() =>
+        this.setState({ pendingForArchivedLists: false })
+      );
     } else {
       removeArchivedListsMetaData();
     }

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -40,11 +40,11 @@ class Cohort extends PureComponent {
   };
 
   componentDidMount() {
-    this.setState({ pendingForDetails: true }, () => {
-      this.fetchData()
-        .then(() => this.setState({ pendingForDetails: false }))
-        .catch(() => this.setState({ pendingForDetails: false }));
-    });
+    this.setState({ pendingForDetails: true });
+
+    this.fetchData()
+      .then(() => this.setState({ pendingForDetails: false }))
+      .catch(() => this.setState({ pendingForDetails: false }));
   }
 
   fetchData = () => {
@@ -77,33 +77,33 @@ class Cohort extends PureComponent {
     const { isListPrivate } = this.state;
     const data = { name, description, userId, cohortId, isListPrivate };
 
-    this.setState({ pendingForListCreation: true }, () => {
-      createList(data)
-        .then(() => {
-          this.setState({ pendingForListCreation: false });
-          this.hideDialog();
-        })
-        .catch(() => {
-          this.setState({ pendingForListCreation: false });
-          this.hideDialog();
-        });
-    });
+    this.setState({ pendingForListCreation: true });
+
+    createList(data)
+      .then(() => {
+        this.setState({ pendingForListCreation: false });
+        this.hideDialog();
+      })
+      .catch(() => {
+        this.setState({ pendingForListCreation: false });
+        this.hideDialog();
+      });
   };
 
   handleCohortArchivization = cohortId => () => {
     const { archiveCohort } = this.props;
 
-    this.setState({ pendingForCohortArchivization: true }, () => {
-      archiveCohort(cohortId)
-        .then(() => {
-          this.setState({ pendingForCohortArchivization: false });
-          this.hideDialog();
-        })
-        .catch(() => {
-          this.setState({ pendingForCohortArchivization: false });
-          this.hideDialog();
-        });
-    });
+    this.setState({ pendingForCohortArchivization: true });
+
+    archiveCohort(cohortId)
+      .then(() => {
+        this.setState({ pendingForCohortArchivization: false });
+        this.hideDialog();
+      })
+      .catch(() => {
+        this.setState({ pendingForCohortArchivization: false });
+        this.hideDialog();
+      });
   };
 
   checkIfArchived = () => {
@@ -140,11 +140,11 @@ class Cohort extends PureComponent {
     } = this.props;
 
     if (areArchivedListsVisible) {
-      this.setState({ pendingForArchivedLists: true }, () => {
-        fetchArchivedListsMetaData()
-          .then(() => this.setState({ pendingForArchivedLists: false }))
-          .catch(() => this.setState({ pendingForArchivedLists: false }));
-      });
+      this.setState({ pendingForArchivedLists: true });
+
+      fetchArchivedListsMetaData()
+        .then(() => this.setState({ pendingForArchivedLists: false }))
+        .catch(() => this.setState({ pendingForArchivedLists: false }));
     } else {
       removeArchivedListsMetaData();
     }

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -24,7 +24,6 @@ import GridList from 'common/components/GridList';
 import { ListType } from 'modules/list';
 import MembersBox from 'common/components/Members';
 import { Routes } from 'common/constants/enums';
-import { noOp } from 'common/utils/noOp';
 import CohortHeader from './components/CohortHeader';
 import Preloader from '../../common/components/Preloader';
 
@@ -42,9 +41,7 @@ class Cohort extends PureComponent {
   componentDidMount() {
     this.setState({ pendingForDetails: true });
 
-    this.fetchData()
-      .then(() => this.setState({ pendingForDetails: false }))
-      .catch(() => this.setState({ pendingForDetails: false }));
+    this.fetchData();
   }
 
   fetchData = () => {
@@ -56,13 +53,16 @@ class Cohort extends PureComponent {
       }
     } = this.props;
 
-    return fetchCohortDetails(id)
+    this.setState({ pendingForDetails: true });
+
+    fetchCohortDetails(id)
       .then(() => {
         if (!this.checkIfArchived()) {
-          fetchListsMetaData(id);
+          return fetchListsMetaData(id);
         }
       })
-      .catch(noOp);
+      .then(() => this.setState({ pendingForDetails: false }))
+      .catch(() => this.setState({ pendingForDetails: false }));
   };
 
   handleListCreation = (name, description) => {

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -39,8 +39,6 @@ class Cohort extends PureComponent {
   };
 
   componentDidMount() {
-    this.setState({ pendingForDetails: true });
-
     this.fetchData();
   }
 

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -201,7 +201,7 @@ class Cohort extends PureComponent {
             pending={pendingForCohortArchivization}
             title={
               pendingForCohortArchivization
-                ? `"${name}" cohort archivization`
+                ? `"${name}" cohort archivization...`
                 : `Do you really want to archive the "${name}" cohort?`
             }
           />
@@ -216,11 +216,7 @@ class Cohort extends PureComponent {
           />
         )}
         {isArchived ? (
-          <ArchivedCohort
-            cohortId={cohortId}
-            name={name}
-            pending={pendingForDetails}
-          />
+          <ArchivedCohort cohortId={cohortId} name={name} />
         ) : (
           <div className="wrapper">
             <div className="cohort">

--- a/client/src/modules/dashboard/index.jsx
+++ b/client/src/modules/dashboard/index.jsx
@@ -13,6 +13,7 @@ import {
 import {
   getArchivedLists,
   getCohortLists,
+  getIsFetchingLists,
   getPrivateLists
 } from 'modules/list/model/selectors';
 import { getCurrentUser } from 'modules/authorization/model/selectors';
@@ -71,7 +72,7 @@ class Dashboard extends Component {
   };
 
   render() {
-    const { archivedLists, privateLists, cohortLists } = this.props;
+    const { archivedLists, cohortLists, isFetching, privateLists } = this.props;
     const { areArchivedListsVisible, isDialogVisible } = this.state;
 
     return (
@@ -82,6 +83,7 @@ class Dashboard extends Component {
             <GridList
               color={CardColorType.ORANGE}
               icon={<ListIcon />}
+              isFetching={isFetching && !areArchivedListsVisible}
               items={privateLists}
               name="Private Lists"
               onAddNew={this.handleDialogVisibility}
@@ -91,6 +93,7 @@ class Dashboard extends Component {
             <GridList
               color={CardColorType.ORANGE}
               icon={<ListIcon />}
+              isFetching={isFetching && !areArchivedListsVisible}
               items={cohortLists}
               name="Cohort's Lists"
               placeholder="There are no lists yet!"
@@ -107,6 +110,7 @@ class Dashboard extends Component {
               <GridList
                 color={CardColorType.ARCHIVED}
                 icon={<ListIcon />}
+                isFetching={isFetching}
                 items={archivedLists}
                 name="Archived lists"
                 placeholder="You have no archived lists!"
@@ -129,9 +133,10 @@ class Dashboard extends Component {
 
 Dashboard.propTypes = {
   archivedLists: PropTypes.objectOf(PropTypes.object),
-  currentUser: UserPropType.isRequired,
-  privateLists: PropTypes.objectOf(PropTypes.object),
   cohortLists: PropTypes.objectOf(PropTypes.object),
+  currentUser: UserPropType.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  privateLists: PropTypes.objectOf(PropTypes.object),
 
   createList: PropTypes.func.isRequired,
   fetchArchivedListsMetaData: PropTypes.func.isRequired,
@@ -143,6 +148,7 @@ const mapStateToProps = state => ({
   archivedLists: getArchivedLists(state),
   cohortLists: getCohortLists(state),
   currentUser: getCurrentUser(state),
+  isFetching: getIsFetchingLists(state),
   privateLists: getPrivateLists(state)
 });
 

--- a/client/src/modules/dashboard/index.jsx
+++ b/client/src/modules/dashboard/index.jsx
@@ -34,11 +34,11 @@ class Dashboard extends Component {
   componentDidMount() {
     const { fetchListsMetaData } = this.props;
 
-    this.setState({ pendingForLists: true }, () => {
-      fetchListsMetaData()
-        .then(() => this.setState({ pendingForLists: false }))
-        .catch(() => this.setState({ pendingForLists: false }));
-    });
+    this.setState({ pendingForLists: true });
+
+    fetchListsMetaData()
+      .then(() => this.setState({ pendingForLists: false }))
+      .catch(() => this.setState({ pendingForLists: false }));
   }
 
   handleDialogVisibility = () =>
@@ -53,17 +53,17 @@ class Dashboard extends Component {
     } = this.props;
     const data = { description, userId, name };
 
-    this.setState({ pendingForListCreation: true }, () => {
-      createList(data)
-        .then(() => {
-          this.setState({ pendingForListCreation: false });
-          this.handleDialogVisibility();
-        })
-        .catch(() => {
-          this.setState({ pendingForListCreation: false });
-          this.handleDialogVisibility();
-        });
-    });
+    this.setState({ pendingForListCreation: true });
+
+    createList(data)
+      .then(() => {
+        this.setState({ pendingForListCreation: false });
+        this.handleDialogVisibility();
+      })
+      .catch(() => {
+        this.setState({ pendingForListCreation: false });
+        this.handleDialogVisibility();
+      });
   };
 
   handleArchivedListsVisibility = () =>
@@ -82,11 +82,11 @@ class Dashboard extends Component {
     } = this.props;
 
     if (areArchivedListsVisible) {
-      this.setState({ pendingForArchivedLists: true }, () => {
-        fetchArchivedListsMetaData()
-          .then(() => this.setState({ pendingForArchivedLists: false }))
-          .catch(() => this.setState({ pendingForArchivedLists: false }));
-      });
+      this.setState({ pendingForArchivedLists: true });
+
+      fetchArchivedListsMetaData()
+        .then(() => this.setState({ pendingForArchivedLists: false }))
+        .catch(() => this.setState({ pendingForArchivedLists: false }));
     } else {
       removeArchivedListsMetaData();
     }

--- a/client/src/modules/dashboard/index.jsx
+++ b/client/src/modules/dashboard/index.jsx
@@ -36,9 +36,9 @@ class Dashboard extends Component {
 
     this.setState({ pendingForLists: true });
 
-    fetchListsMetaData()
-      .then(() => this.setState({ pendingForLists: false }))
-      .catch(() => this.setState({ pendingForLists: false }));
+    fetchListsMetaData().finally(() =>
+      this.setState({ pendingForLists: false })
+    );
   }
 
   handleDialogVisibility = () =>
@@ -55,15 +55,10 @@ class Dashboard extends Component {
 
     this.setState({ pendingForListCreation: true });
 
-    createList(data)
-      .then(() => {
-        this.setState({ pendingForListCreation: false });
-        this.handleDialogVisibility();
-      })
-      .catch(() => {
-        this.setState({ pendingForListCreation: false });
-        this.handleDialogVisibility();
-      });
+    createList(data).finally(() => {
+      this.setState({ pendingForListCreation: false });
+      this.handleDialogVisibility();
+    });
   };
 
   handleArchivedListsVisibility = () =>
@@ -84,9 +79,9 @@ class Dashboard extends Component {
     if (areArchivedListsVisible) {
       this.setState({ pendingForArchivedLists: true });
 
-      fetchArchivedListsMetaData()
-        .then(() => this.setState({ pendingForArchivedLists: false }))
-        .catch(() => this.setState({ pendingForArchivedLists: false }));
+      fetchArchivedListsMetaData().finally(() =>
+        this.setState({ pendingForArchivedLists: false })
+      );
     } else {
       removeArchivedListsMetaData();
     }

--- a/client/src/modules/list/List.scss
+++ b/client/src/modules/list/List.scss
@@ -1,6 +1,5 @@
 .list {
   margin: 30px 0 25px 0;
-  position: relative;
   height: 100%;
   min-height: 100%;
 

--- a/client/src/modules/list/components/ArchivedList.jsx
+++ b/client/src/modules/list/components/ArchivedList.jsx
@@ -6,26 +6,10 @@ import { deleteList, restoreList } from 'modules/list/model/actions';
 import ArchivedMessage from 'common/components/ArchivedMessage';
 
 class ArchivedList extends PureComponent {
-  constructor(props) {
-    super(props);
-
-    const { pending } = this.props;
-    this.state = {
-      pending,
-      pendingMessage: ''
-    };
-  }
-
   handleListRestoring = listId => () => {
-    const { name, restoreList } = this.props;
+    const { restoreList } = this.props;
 
-    this.setState(
-      { pending: true, pendingMessage: `Restoring "${name}" list...` },
-      () =>
-        restoreList(listId).catch(() =>
-          this.setState({ pending: false, pendingMessage: '' })
-        )
-    );
+    return restoreList(listId);
   };
 
   handleListDeletion = id => () => {
@@ -36,14 +20,10 @@ class ArchivedList extends PureComponent {
   render() {
     const { listId, name } = this.props;
 
-    const { pending, pendingMessage } = this.state;
-
     return (
       <ArchivedMessage
         item="list"
         name={name}
-        pending={pending}
-        pendingMessage={pendingMessage}
         onDelete={this.handleListDeletion(listId)}
         onRestore={this.handleListRestoring(listId)}
       />
@@ -54,7 +34,6 @@ class ArchivedList extends PureComponent {
 ArchivedList.propTypes = {
   listId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  pending: PropTypes.bool.isRequired,
 
   deleteList: PropTypes.func.isRequired,
   restoreList: PropTypes.func.isRequired

--- a/client/src/modules/list/components/ArchivedList.jsx
+++ b/client/src/modules/list/components/ArchivedList.jsx
@@ -6,9 +6,26 @@ import { deleteList, restoreList } from 'modules/list/model/actions';
 import ArchivedMessage from 'common/components/ArchivedMessage';
 
 class ArchivedList extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { pending } = this.props;
+    this.state = {
+      pending,
+      pendingMessage: ''
+    };
+  }
+
   handleListRestoring = listId => () => {
-    const { restoreList } = this.props;
-    restoreList(listId);
+    const { name, restoreList } = this.props;
+
+    this.setState(
+      { pending: true, pendingMessage: `Restoring "${name}" list...` },
+      () =>
+        restoreList(listId).catch(() =>
+          this.setState({ pending: false, pendingMessage: '' })
+        )
+    );
   };
 
   handleListDeletion = id => () => {
@@ -19,10 +36,14 @@ class ArchivedList extends PureComponent {
   render() {
     const { listId, name } = this.props;
 
+    const { pending, pendingMessage } = this.state;
+
     return (
       <ArchivedMessage
         item="list"
         name={name}
+        pending={pending}
+        pendingMessage={pendingMessage}
         onDelete={this.handleListDeletion(listId)}
         onRestore={this.handleListRestoring(listId)}
       />
@@ -33,6 +54,7 @@ class ArchivedList extends PureComponent {
 ArchivedList.propTypes = {
   listId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  pending: PropTypes.bool.isRequired,
 
   deleteList: PropTypes.func.isRequired,
   restoreList: PropTypes.func.isRequired

--- a/client/src/modules/list/components/ArchivedList.jsx
+++ b/client/src/modules/list/components/ArchivedList.jsx
@@ -14,6 +14,7 @@ class ArchivedList extends PureComponent {
 
   handleListDeletion = id => () => {
     const { deleteList } = this.props;
+
     return deleteList(id);
   };
 

--- a/client/src/modules/list/components/ListHeader.jsx
+++ b/client/src/modules/list/components/ListHeader.jsx
@@ -156,37 +156,35 @@ class ListHeader extends PureComponent {
       pendingForDescription
     } = this.state;
 
-    if (pendingForDescription) return <Preloader size={PreloaderSize.SMALL} />;
+    if (pendingForDescription) {
+      return <Preloader size={PreloaderSize.SMALL} />;
+    }
 
-    return (
+    return isDescriptionTextareaVisible ? (
+      <DescriptionTextarea
+        description={description}
+        onClick={this.handleClick}
+        onDescriptionChange={this.handleDescriptionChange}
+        onKeyPress={this.handleKeyPress}
+      />
+    ) : (
       <Fragment>
-        {isDescriptionTextareaVisible ? (
-          <DescriptionTextarea
-            description={description}
-            onClick={this.handleClick}
-            onDescriptionChange={this.handleDescriptionChange}
-            onKeyPress={this.handleKeyPress}
-          />
+        {description ? (
+          <p
+            className="list-header__description"
+            data-id="description"
+            onClick={this.handleDescriptionTextareaVisibility}
+          >
+            {description}
+          </p>
         ) : (
-          <Fragment>
-            {description ? (
-              <p
-                className="list-header__description"
-                data-id="description"
-                onClick={this.handleDescriptionTextareaVisibility}
-              >
-                {description}
-              </p>
-            ) : (
-              <button
-                className="list-header__button link-button"
-                onClick={this.handleDescriptionTextareaVisibility}
-                type="button"
-              >
-                Add description
-              </button>
-            )}
-          </Fragment>
+          <button
+            className="list-header__button link-button"
+            onClick={this.handleDescriptionTextareaVisibility}
+            type="button"
+          >
+            Add description
+          </button>
         )}
       </Fragment>
     );
@@ -195,26 +193,24 @@ class ListHeader extends PureComponent {
   renderName = () => {
     const { name, isNameInputVisible, pendingForName } = this.state;
 
-    if (pendingForName) return <Preloader size={PreloaderSize.SMALL} />;
+    if (pendingForName) {
+      return <Preloader size={PreloaderSize.SMALL} />;
+    }
 
-    return (
-      <Fragment>
-        {isNameInputVisible ? (
-          <NameInput
-            name={name}
-            onClick={this.handleClick}
-            onKeyPress={this.handleKeyPress}
-            onNameChange={this.handleNameChange}
-          />
-        ) : (
-          <h1
-            className="list-header__heading"
-            onClick={this.handleNameInputVisibility}
-          >
-            {name}
-          </h1>
-        )}
-      </Fragment>
+    return isNameInputVisible ? (
+      <NameInput
+        name={name}
+        onClick={this.handleClick}
+        onKeyPress={this.handleKeyPress}
+        onNameChange={this.handleNameChange}
+      />
+    ) : (
+      <h1
+        className="list-header__heading"
+        onClick={this.handleNameInputVisibility}
+      >
+        {name}
+      </h1>
     );
   };
 

--- a/client/src/modules/list/components/ListHeader.jsx
+++ b/client/src/modules/list/components/ListHeader.jsx
@@ -107,6 +107,7 @@ class ListHeader extends PureComponent {
 
     if (name.trim().length >= 1) {
       this.setState({ pendingForName: true });
+
       updateList(id, { name }).finally(() =>
         this.setState({ isNameInputVisible: false, pendingForName: false })
       );
@@ -140,13 +141,8 @@ class ListHeader extends PureComponent {
     });
 
     updateList(id, { description: updatedDescription })
-      .then(() =>
-        this.setState({
-          description: updatedDescription,
-          pendingForDescription: false
-        })
-      )
-      .catch(() => this.setState({ pendingForDescription: false }));
+      .then(() => this.setState({ description: updatedDescription }))
+      .finally(() => this.setState({ pendingForDescription: false }));
   };
 
   renderDescription = () => {

--- a/client/src/modules/list/components/ListHeader.jsx
+++ b/client/src/modules/list/components/ListHeader.jsx
@@ -106,15 +106,14 @@ class ListHeader extends PureComponent {
     }
 
     if (name.trim().length >= 1) {
-      this.setState({ pendingForName: true }, () => {
-        updateList(id, { name })
-          .then(() =>
-            this.setState({ isNameInputVisible: false, pendingForName: false })
-          )
-          .catch(() =>
-            this.setState({ isNameInputVisible: false, pendingForName: false })
-          );
-      });
+      this.setState({ pendingForName: true });
+      updateList(id, { name })
+        .then(() =>
+          this.setState({ isNameInputVisible: false, pendingForName: false })
+        )
+        .catch(() =>
+          this.setState({ isNameInputVisible: false, pendingForName: false })
+        );
     }
   };
 
@@ -139,21 +138,20 @@ class ListHeader extends PureComponent {
 
     const updatedDescription = _isEmpty(_trim(description)) ? '' : description;
 
-    this.setState(
-      { isDescriptionTextareaVisible: false, pendingForDescription: true },
-      () => {
-        updateList(id, { description: updatedDescription })
-          .then(() =>
-            this.setState({
-              description: updatedDescription,
-              pendingForDescription: false
-            })
-          )
-          .catch(() => {
-            this.setState({ pendingForDescription: false });
-          });
-      }
-    );
+    this.setState({
+      isDescriptionTextareaVisible: false,
+      pendingForDescription: true
+    });
+    updateList(id, { description: updatedDescription })
+      .then(() =>
+        this.setState({
+          description: updatedDescription,
+          pendingForDescription: false
+        })
+      )
+      .catch(() => {
+        this.setState({ pendingForDescription: false });
+      });
   };
 
   renderDescription = () => {

--- a/client/src/modules/list/components/ListHeader.jsx
+++ b/client/src/modules/list/components/ListHeader.jsx
@@ -107,13 +107,9 @@ class ListHeader extends PureComponent {
 
     if (name.trim().length >= 1) {
       this.setState({ pendingForName: true });
-      updateList(id, { name })
-        .then(() =>
-          this.setState({ isNameInputVisible: false, pendingForName: false })
-        )
-        .catch(() =>
-          this.setState({ isNameInputVisible: false, pendingForName: false })
-        );
+      updateList(id, { name }).finally(() =>
+        this.setState({ isNameInputVisible: false, pendingForName: false })
+      );
     }
   };
 
@@ -142,6 +138,7 @@ class ListHeader extends PureComponent {
       isDescriptionTextareaVisible: false,
       pendingForDescription: true
     });
+
     updateList(id, { description: updatedDescription })
       .then(() =>
         this.setState({
@@ -149,9 +146,7 @@ class ListHeader extends PureComponent {
           pendingForDescription: false
         })
       )
-      .catch(() => {
-        this.setState({ pendingForDescription: false });
-      });
+      .catch(() => this.setState({ pendingForDescription: false }));
   };
 
   renderDescription = () => {
@@ -161,9 +156,9 @@ class ListHeader extends PureComponent {
       pendingForDescription
     } = this.state;
 
-    return pendingForDescription ? (
-      <Preloader size={PreloaderSize.SMALL} />
-    ) : (
+    if (pendingForDescription) return <Preloader size={PreloaderSize.SMALL} />;
+
+    return (
       <Fragment>
         {isDescriptionTextareaVisible ? (
           <DescriptionTextarea
@@ -200,9 +195,9 @@ class ListHeader extends PureComponent {
   renderName = () => {
     const { name, isNameInputVisible, pendingForName } = this.state;
 
-    return pendingForName ? (
-      <Preloader size={PreloaderSize.SMALL} />
-    ) : (
+    if (pendingForName) return <Preloader size={PreloaderSize.SMALL} />;
+
+    return (
       <Fragment>
         {isNameInputVisible ? (
           <NameInput

--- a/client/src/modules/list/components/ListHeader.jsx
+++ b/client/src/modules/list/components/ListHeader.jsx
@@ -10,6 +10,7 @@ import { updateList } from 'modules/list/model/actions';
 import { RouterMatchPropType } from 'common/constants/propTypes';
 import NameInput from 'common/components/NameInput';
 import DescriptionTextarea from 'common/components/DescriptionTextarea';
+import Preloader, { PreloaderSize } from 'common/components/Preloader';
 
 class ListHeader extends PureComponent {
   constructor(props) {
@@ -24,7 +25,9 @@ class ListHeader extends PureComponent {
       description: trimmedDescription,
       isDescriptionTextareaVisible: false,
       isNameInputVisible: false,
-      name
+      name,
+      pendingForDescription: false,
+      pendingForName: false
     };
   }
 
@@ -103,8 +106,15 @@ class ListHeader extends PureComponent {
     }
 
     if (name.trim().length >= 1) {
-      updateList(id, { name });
-      this.setState({ isNameInputVisible: false });
+      this.setState({ pendingForName: true }, () => {
+        updateList(id, { name })
+          .then(() =>
+            this.setState({ isNameInputVisible: false, pendingForName: false })
+          )
+          .catch(() =>
+            this.setState({ isNameInputVisible: false, pendingForName: false })
+          );
+      });
     }
   };
 
@@ -127,66 +137,91 @@ class ListHeader extends PureComponent {
       return;
     }
 
-    if (_isEmpty(_trim(description))) {
-      updateList(id, { description: '' });
-      this.setState({ description: '' });
-      return;
-    }
+    const updatedDescription = _isEmpty(_trim(description)) ? '' : description;
 
-    updateList(id, { description });
-    this.setState({ isDescriptionTextareaVisible: false });
+    this.setState(
+      { isDescriptionTextareaVisible: false, pendingForDescription: true },
+      () => {
+        updateList(id, { description: updatedDescription })
+          .then(() =>
+            this.setState({
+              description: updatedDescription,
+              pendingForDescription: false
+            })
+          )
+          .catch(() => {
+            this.setState({ pendingForDescription: false });
+          });
+      }
+    );
   };
 
   renderDescription = () => {
-    const { description, isDescriptionTextareaVisible } = this.state;
+    const {
+      description,
+      isDescriptionTextareaVisible,
+      pendingForDescription
+    } = this.state;
 
-    return isDescriptionTextareaVisible ? (
-      <DescriptionTextarea
-        description={description}
-        onClick={this.handleClick}
-        onDescriptionChange={this.handleDescriptionChange}
-        onKeyPress={this.handleKeyPress}
-      />
+    return pendingForDescription ? (
+      <Preloader size={PreloaderSize.SMALL} />
     ) : (
       <Fragment>
-        {description ? (
-          <p
-            className="cohort-header__description"
-            data-id="description"
-            onClick={this.handleDescriptionTextareaVisibility}
-          >
-            {description}
-          </p>
+        {isDescriptionTextareaVisible ? (
+          <DescriptionTextarea
+            description={description}
+            onClick={this.handleClick}
+            onDescriptionChange={this.handleDescriptionChange}
+            onKeyPress={this.handleKeyPress}
+          />
         ) : (
-          <button
-            className="cohort-header__button link-button"
-            onClick={this.handleDescriptionTextareaVisibility}
-            type="button"
-          >
-            Add description
-          </button>
+          <Fragment>
+            {description ? (
+              <p
+                className="list-header__description"
+                data-id="description"
+                onClick={this.handleDescriptionTextareaVisibility}
+              >
+                {description}
+              </p>
+            ) : (
+              <button
+                className="list-header__button link-button"
+                onClick={this.handleDescriptionTextareaVisibility}
+                type="button"
+              >
+                Add description
+              </button>
+            )}
+          </Fragment>
         )}
       </Fragment>
     );
   };
 
   renderName = () => {
-    const { name, isNameInputVisible } = this.state;
+    const { name, isNameInputVisible, pendingForName } = this.state;
 
-    return isNameInputVisible ? (
-      <NameInput
-        name={name}
-        onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
-        onNameChange={this.handleNameChange}
-      />
+    return pendingForName ? (
+      <Preloader size={PreloaderSize.SMALL} />
     ) : (
-      <h1
-        className="list-header__heading"
-        onClick={this.handleNameInputVisibility}
-      >
-        {name}
-      </h1>
+      <Fragment>
+        {isNameInputVisible ? (
+          <NameInput
+            name={name}
+            onClick={this.handleClick}
+            onKeyPress={this.handleKeyPress}
+            onNameChange={this.handleNameChange}
+          />
+        ) : (
+          <h1
+            className="list-header__heading"
+            onClick={this.handleNameInputVisibility}
+          >
+            {name}
+          </h1>
+        )}
+      </Fragment>
     );
   };
 
@@ -197,7 +232,7 @@ class ListHeader extends PureComponent {
           <ListIcon />
           {this.renderName()}
         </div>
-        {this.renderDescription()}
+        <div className="list-header__bottom">{this.renderDescription()}</div>
       </div>
     );
   }

--- a/client/src/modules/list/components/ListHeader.scss
+++ b/client/src/modules/list/components/ListHeader.scss
@@ -12,8 +12,14 @@
   }
 
   &__top {
+    position: relative;
     display: flex;
     align-items: center;
+  }
+
+  &__bottom {
+    position: relative;
+    min-height: 35px;
   }
 
   &__heading {

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -125,11 +125,7 @@ class List extends Component {
           )}
         </Toolbar>
         {isArchived ? (
-          <ArchivedList
-            listId={listId}
-            name={name}
-            pending={pendingForDetails}
-          />
+          <ArchivedList listId={listId} name={name} />
         ) : (
           <div className="wrapper">
             <div className="list">
@@ -178,7 +174,7 @@ class List extends Component {
             pending={pendingForListArchivization}
             title={
               pendingForListArchivization
-                ? `"${name}" list archivization`
+                ? `"${name}" list archivization...`
                 : `Do you really want to archive the "${name}" list?`
             }
           />

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -34,9 +34,9 @@ class List extends Component {
   componentDidMount() {
     if (this.checkIfArchived()) {
       this.setState({ pendingForDetails: true });
-      this.fetchData()
-        .then(() => this.setState({ pendingForDetails: false }))
-        .catch(() => this.setState({ pendingForDetails: false }));
+      this.fetchData().finally(() =>
+        this.setState({ pendingForDetails: false })
+      );
     }
   }
 
@@ -54,15 +54,10 @@ class List extends Component {
     const { archiveList } = this.props;
 
     this.setState({ pendingForListArchivization: true });
-    archiveList(listId)
-      .then(() => {
-        this.setState({ pendingForListArchivization: false });
-        this.hideDialog();
-      })
-      .catch(() => {
-        this.setState({ pendingForListArchivization: false });
-        this.hideDialog();
-      });
+    archiveList(listId).finally(() => {
+      this.setState({ pendingForListArchivization: false });
+      this.hideDialog();
+    });
   };
 
   checkIfArchived = () => {

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -33,11 +33,10 @@ class List extends Component {
 
   componentDidMount() {
     if (this.checkIfArchived()) {
-      this.setState({ pendingForDetails: true }, () => {
-        this.fetchData()
-          .then(() => this.setState({ pendingForDetails: false }))
-          .catch(() => this.setState({ pendingForDetails: false }));
-      });
+      this.setState({ pendingForDetails: true });
+      this.fetchData()
+        .then(() => this.setState({ pendingForDetails: false }))
+        .catch(() => this.setState({ pendingForDetails: false }));
     }
   }
 
@@ -54,17 +53,16 @@ class List extends Component {
   handleListArchivization = listId => () => {
     const { archiveList } = this.props;
 
-    this.setState({ pendingForListArchivization: true }, () => {
-      archiveList(listId)
-        .then(() => {
-          this.setState({ pendingForListArchivization: false });
-          this.hideDialog();
-        })
-        .catch(() => {
-          this.setState({ pendingForListArchivization: false });
-          this.hideDialog();
-        });
-    });
+    this.setState({ pendingForListArchivization: true });
+    archiveList(listId)
+      .then(() => {
+        this.setState({ pendingForListArchivization: false });
+        this.hideDialog();
+      })
+      .catch(() => {
+        this.setState({ pendingForListArchivization: false });
+        this.hideDialog();
+      });
   };
 
   checkIfArchived = () => {


### PR DESCRIPTION
As we agreed, preloader animations were added everywhere they were needed, except of actions/features concerning list's items, because their code is changed and edited in Adam's tasks.

![chrome-capture](https://user-images.githubusercontent.com/25374390/56096844-59e5c000-5eed-11e9-9a5c-dca7f3625dac.gif)
![chrome-capture (1)](https://user-images.githubusercontent.com/25374390/56096804-168b5180-5eed-11e9-8617-cf70606fb106.gif)
![chrome-capture (2)](https://user-images.githubusercontent.com/25374390/56096809-18edab80-5eed-11e9-9335-e8140895cb4f.gif)
![chrome-capture (3)](https://user-images.githubusercontent.com/25374390/56096816-1d19c900-5eed-11e9-8482-cd2e20151923.gif)
![chrome-capture (4)](https://user-images.githubusercontent.com/25374390/56096820-286cf480-5eed-11e9-9e65-90ecb58dc567.gif)
![chrome-capture (6)](https://user-images.githubusercontent.com/25374390/56096826-391d6a80-5eed-11e9-8be9-7f77d7dbe07d.gif)
![chrome-capture (7)](https://user-images.githubusercontent.com/25374390/56096822-2e62d580-5eed-11e9-92e5-1c968fdd92d5.gif)







