### PR TITLE
Change private to limited, public to shared

### DIFF
--- a/client/src/common/components/Form.jsx
+++ b/client/src/common/components/Form.jsx
@@ -83,8 +83,8 @@ class Form extends PureComponent {
             className="form__select primary-select"
             onChange={this.handleSelect}
           >
-            <option value={ListType.PRIVATE}>{ListType.PRIVATE}</option>
-            <option value={ListType.PUBLIC}>{ListType.PUBLIC}</option>
+            <option value={ListType.LIMITED}>{ListType.LIMITED}</option>
+            <option value={ListType.SHARED}>{ListType.SHARED}</option>
           </select>
         )}
       </form>

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -116,10 +116,10 @@ class Cohort extends PureComponent {
   };
 
   handleListType = isPrivate =>
-    this.setState({ isListPrivate: isPrivate === ListType.PRIVATE });
+    this.setState({ isListPrivate: isPrivate === ListType.LIMITED });
 
   handleListType = isPrivate =>
-    this.setState({ isListPrivate: isPrivate === ListType.PRIVATE });
+    this.setState({ isListPrivate: isPrivate === ListType.LIMITED });
 
   render() {
     const {

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -19,8 +19,8 @@ import { Routes } from 'common/constants/enums';
 import ListHeader from './components/ListHeader';
 
 export const ListType = Object.freeze({
-  PRIVATE: 'private',
-  PUBLIC: 'public'
+  LIMITED: 'limited',
+  SHARED: 'shared'
 });
 
 class List extends Component {


### PR DESCRIPTION
I have only changed PRIVATE and PUBLIC on front end layer, which is visible to the customer. 
In my opinion, we shouldn't change implementation details of LIST model property` isPrivate`,
because on the next meeting customer can say that he wants not LIMITED but 'PROTECTED' and so on.
The list actually can have two states - private or public, and that's what it's labeled should be managed on the front end, not in implementation details which are for us programmers. @marekrozmus  Correct me if I'm wrong.

![list_model_js_—_projects](https://user-images.githubusercontent.com/27632432/56264711-a0067380-60e7-11e9-9ee8-c0ff99d57d50.png)

