### PR TITLE
[EOC-170] Add links functionality to comments

### DIFF
--- a/client/src/app/styles/_colors.scss
+++ b/client/src/app/styles/_colors.scss
@@ -38,6 +38,7 @@ $google-blue: #4285f4;
 $gray-bg: $gray2;
 $gray-bg2: $gray3;
 $item-border: $gray3;
+$link-color: $dark-orange;
 $message-bg-gray: $gray1;
 $message-bg-green: $green;
 $message-bg-red: $red;

--- a/client/src/common/components/Comments/Comment.jsx
+++ b/client/src/common/components/Comments/Comment.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Linkify from 'react-linkify';
 
 import { UserIcon } from 'assets/images/icons';
 import { dateFromString } from 'common/utils/helpers';
@@ -20,7 +21,13 @@ const Comment = ({ comment }) => {
       <div className="comment__body">
         <span className="comment__author">{authorName}</span>
         <span className="comment__date">{date}</span>
-        <p className="comment__content">{text}</p>
+        <p className="comment__content">
+          <Linkify
+            properties={{ target: '_blank', className: 'comment__link' }}
+          >
+            {text}
+          </Linkify>
+        </p>
       </div>
     </div>
   );

--- a/client/src/common/components/Comments/Comment.scss
+++ b/client/src/common/components/Comments/Comment.scss
@@ -31,6 +31,16 @@
     color: $text-normal;
   }
 
+  &__link {
+    font-style: italic;
+    text-decoration: underline;
+    color: $link-color;
+
+    &:visited {
+      color: $text-normal;
+    }
+  }
+
   &__avatar {
     margin-right: 16px;
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "16.5.2",
     "react-cookie-consent": "2.2.2",
     "react-dom": "16.5.2",
+    "react-linkify": "0.2.2",
     "react-popper": "1.3.3",
     "react-redux": "5.1.1",
     "react-router-dom": "4.3.1",


### PR DESCRIPTION
I used react-linkify lib to detect link in text and convert them to a a tags.

![chrome-capture](https://user-images.githubusercontent.com/25374390/57602047-6007a480-755e-11e9-847d-0c8355d22c51.gif)
