### PR TITLE
[EOC-180] Change avatar service in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ This project uses:
 
 - FontAwesome Free. Check [license]('https://fontawesome.com/license').,
 - Google [Trademark Logo]('https://www.google.com/permissions/logos-trademarks/') : ©2018 Google LLC All rights reserved. Google and the Google logo are registered trademarks of Google LLC.
-- Avatars [project page](https://avatars.dicebear.com/).
+- Avatars project [project page](https://avatars.dicebear.com/). Avatars project is distributed under MIT license [license](https://github.com/DiceBear/avatars/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ This project uses:
 
 - FontAwesome Free. Check [license]('https://fontawesome.com/license').,
 - Google [Trademark Logo]('https://www.google.com/permissions/logos-trademarks/') : ©2018 Google LLC All rights reserved. Google and the Google logo are registered trademarks of Google LLC.
+- Avatars [project page](https://avatars.dicebear.com/).

--- a/server/seed/demoSeed/generateUsers.js
+++ b/server/seed/demoSeed/generateUsers.js
@@ -12,7 +12,8 @@ const {
 const createDemoUser = () => ({
   _id: userId,
   accessToken: '012346789',
-  avatarUrl: 'https://i.pravatar.cc/40?img=1',
+  avatarUrl:
+    'https://avatars.dicebear.com/v2/avataaars/eoc-demo%40examle.com.svg?options[top][]=longHair&options[top][]=shortHair&options[topChance]=100&options[hatColor][]=black&options[hairColor][]=brown&options[facialHair][]=medium&options[facialHairChance]=100&options[facialHairColor][]=brown&options[clothesColor][]=blue&options[eyes][]=defaultValue&options[mouth][]=smile&options[skin][]=brown',
   displayName: 'Demo',
   email: 'demo@example.com',
   idFromProvider,
@@ -25,7 +26,8 @@ const generateUsers = demoUserId => [
   {
     _id: ObjectId(),
     accessToken: '012346789',
-    avatarUrl: 'https://i.pravatar.cc/40?img=3',
+    avatarUrl:
+      'https://avatars.dicebear.com/v2/avataaars/eoc-joe-doe.com.svg?options[top][]=shortHair&options[top][]=longHair&options[hairColor][]=brown&options[clothesColor][]=red&options[eyes][]=defaultValue&options[mouth][]=defaultValue&options[skin][]=pale',
     displayName: 'John Doe',
     email: 'john@doe.com',
     idFromProvider,
@@ -36,7 +38,8 @@ const generateUsers = demoUserId => [
   {
     _id: ObjectId(),
     accessToken: '012346789',
-    avatarUrl: 'https://i.pravatar.cc/40?img=5',
+    avatarUrl:
+      'https://avatars.dicebear.com/v2/avataaars/eoc-amanda-smith.com.svg?options[hairColor][]=black',
     displayName: 'Amanda Smith',
     email: 'amanda.smith@example.com',
     idFromProvider,
@@ -47,7 +50,8 @@ const generateUsers = demoUserId => [
   {
     _id: ObjectId(),
     accessToken: '012346789',
-    avatarUrl: 'https://i.pravatar.cc/40?img=7',
+    avatarUrl:
+      'https://avatars.dicebear.com/v2/avataaars/eoc-william-logan.com.svg?options[top][]=shortHair&options[hairColor][]=black&options[clothes][]=sweater&options[clothesColor][]=heather&options[eyes][]=happy&options[mouth][]=smile&options[skin][]=light',
     displayName: 'William Logan',
     email: 'wlogan@test.pl',
     idFromProvider,
@@ -58,7 +62,8 @@ const generateUsers = demoUserId => [
   {
     _id: ObjectId(),
     accessToken: '012346789',
-    avatarUrl: 'https://i.pravatar.cc/40?img=9',
+    avatarUrl:
+      'https://avatars.dicebear.com/v2/avataaars/eoc-joan-wood.com.svg?options[top][]=shortHair&options[top][]=longHair&options[hairColor][]=blonde&options[clothesColor][]=red&options[eyes][]=defaultValue&options[mouth][]=defaultValue&options[skin][]=pale',
     displayName: 'Joan Wood',
     email: 'joan.wood@example.uk',
     idFromProvider,


### PR DESCRIPTION
I used [avatars](https://avatars.dicebear.com/) API.

To remove all demo users with old API run:
```
npm run clear-demo
```
To remove main demo user with old API:
```
mongo --shell
use eoc
db.users.deleteOne({ _id: ObjectId("<DEMO_USER_ID from server/common/variables.js>" ) })
```