### PR TITLE
[EOC-199] Reset css [BUG]

### DIFF
--- a/client/src/app/styles/_forms.scss
+++ b/client/src/app/styles/_forms.scss
@@ -69,3 +69,8 @@
   padding: 6px 25px 6px 8px;
   box-shadow: 0 1px 3px rgba($shadow-color, 0.15);
 }
+
+input:disabled,
+textarea:disabled {
+  background: transparent;
+}


### PR DESCRIPTION
**Mayer Reset.css** or **normalize.css**
do not apply any styles for :disabled, :active pseudo classes.
We need to handle this manually and test across browsers. 

I have tried with normalize.css but whole app styles were broken and need a lot of fixing and reviewing what is broken ( which will take a few hours to fix).
For now, I have added my own fix, but we need to merge and test it on production server. I can't reproduce this bug on my browser.