### PR TITLE
[EOC-261] socket adding members to a cohort

### DIFF
--- a/client/src/app/index.jsx
+++ b/client/src/app/index.jsx
@@ -4,21 +4,26 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import en from 'react-intl/locale-data/en';
+import * as io from 'socket.io-client';
 
 import enData from '../locales/en.json';
 import './styles/index.scss';
 import Layout from './components/Layout';
 import configureStore from './model/store';
 import history from 'common/utils/history';
+import SocketContext from 'common/context/socket-context';
 
 addLocaleData([...en]);
 const store = configureStore();
+const socket = io();
 
 ReactDOM.render(
   <Provider store={store}>
     <IntlProvider locale="en" messages={enData}>
       <Router history={history}>
-        <Layout />
+        <SocketContext.Provider value={socket}>
+          <Layout />
+        </SocketContext.Provider>
       </Router>
     </IntlProvider>
   </Provider>,

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -201,8 +201,10 @@ class MembersBox extends PureComponent {
 
   render() {
     const { context, email, isInvitationBoxVisible } = this.state;
-    const { members } = this.props;
+    const { members, socket } = this.props;
     const currentUser = members[context];
+
+    console.log(socket);
 
     return (
       <div className="members-box">
@@ -235,6 +237,7 @@ MembersBox.propTypes = {
   match: RouterMatchPropType.isRequired,
   members: PropTypes.objectOf(PropTypes.object).isRequired,
   route: PropTypes.string.isRequired,
+  socket: PropTypes.objectOf(PropTypes.any).isRequired,
   type: PropTypes.string,
 
   addCohortMember: PropTypes.func.isRequired,

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -201,10 +201,8 @@ class MembersBox extends PureComponent {
 
   render() {
     const { context, email, isInvitationBoxVisible } = this.state;
-    const { members, socket } = this.props;
+    const { members } = this.props;
     const currentUser = members[context];
-
-    console.log(socket);
 
     return (
       <div className="members-box">
@@ -237,7 +235,6 @@ MembersBox.propTypes = {
   match: RouterMatchPropType.isRequired,
   members: PropTypes.objectOf(PropTypes.object).isRequired,
   route: PropTypes.string.isRequired,
-  socket: PropTypes.objectOf(PropTypes.any).isRequired,
   type: PropTypes.string,
 
   addCohortMember: PropTypes.func.isRequired,

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
+import _flowRight from 'lodash/flowRight';
 
 import { RouterMatchPropType } from 'common/constants/propTypes';
 import { PlusIcon, DotsIcon } from 'assets/images/icons';
@@ -14,6 +15,7 @@ import { Routes } from 'common/constants/enums';
 import { UserAddingStatus, MEMBERS_DISPLAY_LIMIT } from './const';
 import InviteNewUser from './components/InviteNewUser';
 import { inviteUser } from './model/actions';
+import withSocket from 'common/hoc/withSocket';
 
 class MembersBox extends PureComponent {
   constructor(props) {
@@ -51,13 +53,14 @@ class MembersBox extends PureComponent {
       match: {
         params: { id }
       },
-      route
+      route,
+      socket
     } = this.props;
 
     const action = route === Routes.COHORT ? addCohortMember : addListViewer;
 
     this.setState({ pending: true });
-    action(id, email).then(resp => {
+    action(id, email, socket).then(resp => {
       if (resp === UserAddingStatus.ADDED) {
         this.setState({ pending: false });
         this.hideForm();
@@ -234,6 +237,7 @@ MembersBox.propTypes = {
   isPrivateList: PropTypes.bool,
   match: RouterMatchPropType.isRequired,
   members: PropTypes.objectOf(PropTypes.object).isRequired,
+  socket: PropTypes.objectOf(PropTypes.any),
   route: PropTypes.string.isRequired,
   type: PropTypes.string,
 
@@ -244,9 +248,11 @@ MembersBox.propTypes = {
   onListLeave: PropTypes.func
 };
 
-export default withRouter(
+export default _flowRight(
+  withSocket,
+  withRouter,
   connect(
     null,
     { addCohortMember, addListViewer, inviteUser }
-  )(MembersBox)
-);
+  )
+)(MembersBox);

--- a/client/src/common/context/socket-context.js
+++ b/client/src/common/context/socket-context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const SocketContext = React.createContext();
+
+export default SocketContext;

--- a/client/src/common/hoc/withSocket.js
+++ b/client/src/common/hoc/withSocket.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import SocketContext from 'common/context/socket-context';
+
+const withSocket = WrappedComponent => props => (
+  <SocketContext.Consumer>
+    {socket => <WrappedComponent {...props} socket={socket} />}
+  </SocketContext.Consumer>
+);
+
+export default withSocket;

--- a/client/src/modules/cohort/components/Cohorts.jsx
+++ b/client/src/modules/cohort/components/Cohorts.jsx
@@ -47,7 +47,7 @@ class Cohorts extends Component {
       this.setState({ pendingForCohorts: false })
     );
 
-    socket.emit('joinCohortsRoom', id);
+    socket.emit('enterCohortsView', id);
     this.receiveWSEvents();
   }
 
@@ -57,7 +57,7 @@ class Cohorts extends Component {
       socket
     } = this.props;
 
-    socket.emit('leavingCohortsRoom', id);
+    socket.emit('leavingCohortsView', id);
   }
 
   receiveWSEvents = () => {

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -79,11 +79,12 @@ class Cohort extends PureComponent {
     const {
       match: {
         params: { id: prevId }
-      }
+      },
+      socket
     } = prevProps;
 
     if (id !== prevId) {
-      this.socket.emit('leavingCohortRoom', prevId);
+      socket.emit('leavingCohortRoom', prevId);
       this.fetchData();
     }
   }
@@ -92,10 +93,11 @@ class Cohort extends PureComponent {
     const {
       match: {
         params: { id: cohortId }
-      }
+      },
+      socket
     } = this.props;
 
-    this.socket.emit('leavingCohortRoom', cohortId);
+    socket.emit('leavingCohortRoom', cohortId);
 
     this.pendingPromises.forEach(promise => promise.abort());
   }

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -48,23 +48,16 @@ import { CohortActionTypes } from './model/actionTypes';
 class Cohort extends PureComponent {
   pendingPromises = [];
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      areArchivedListsVisible: false,
-      breadcrumbs: [],
-      dialogContext: null,
-      pendingForArchivedLists: false,
-      pendingForDetails: false,
-      pendingForListCreation: false,
-      pendingForCohortArchivization: false,
-      socket: undefined,
-      type: ListType.LIMITED
-    };
-
-    this.socket = undefined;
-  }
+  state = {
+    areArchivedListsVisible: false,
+    breadcrumbs: [],
+    dialogContext: null,
+    pendingForArchivedLists: false,
+    pendingForDetails: false,
+    pendingForListCreation: false,
+    pendingForCohortArchivization: false,
+    type: ListType.LIMITED
+  };
 
   componentDidMount() {
     this.fetchData();
@@ -302,8 +295,7 @@ class Cohort extends PureComponent {
       pendingForArchivedLists,
       pendingForCohortArchivization,
       pendingForDetails,
-      pendingForListCreation,
-      socket
+      pendingForListCreation
     } = this.state;
 
     return (
@@ -352,7 +344,6 @@ class Cohort extends PureComponent {
                   members={members}
                   onCohortLeave={this.handleLeave}
                   route={Routes.COHORT}
-                  socket={socket}
                 />
                 <CollectionView
                   color={ColorType.ORANGE}

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import _flowRight from 'lodash/flowRight';
+import io from 'socket.io-client';
 
 import {
   getCohortActiveLists,
@@ -40,16 +41,22 @@ import Breadcrumbs from 'common/components/Breadcrumbs';
 import { getCurrentUser } from 'modules/authorization/model/selectors';
 
 class Cohort extends PureComponent {
-  state = {
-    areArchivedListsVisible: false,
-    breadcrumbs: [],
-    dialogContext: null,
-    pendingForArchivedLists: false,
-    pendingForDetails: false,
-    pendingForListCreation: false,
-    pendingForCohortArchivization: false,
-    type: ListType.LIMITED
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      areArchivedListsVisible: false,
+      breadcrumbs: [],
+      dialogContext: null,
+      pendingForArchivedLists: false,
+      pendingForDetails: false,
+      pendingForListCreation: false,
+      pendingForCohortArchivization: false,
+      type: ListType.LIMITED
+    };
+
+    this.socket = undefined;
+  }
 
   componentDidMount() {
     this.fetchData();

--- a/client/src/modules/cohort/model/actions.js
+++ b/client/src/modules/cohort/model/actions.js
@@ -283,13 +283,15 @@ export const fetchCohortDetails = cohortId => dispatch =>
       throw err;
     });
 
-export const addCohortMember = (cohortId, email) => dispatch =>
+export const addCohortMember = (cohortId, email, socket) => dispatch =>
   patchData(`/api/cohorts/${cohortId}/add-member`, {
     email
   })
     .then(resp => resp.json())
     .then(json => {
       if (json._id) {
+        const data = { cohortId, json };
+        socket.emit(CohortActionTypes.ADD_MEMBER_SUCCESS, data);
         dispatch(addMemberSuccess(json, cohortId));
 
         return UserAddingStatus.ADDED;
@@ -304,6 +306,9 @@ export const addCohortMember = (cohortId, email) => dispatch =>
         data: email
       });
     });
+
+export const addCohortMemberWS = (cohortId, json) => dispatch =>
+  dispatch(addMemberSuccess(json, cohortId));
 
 export const removeCohortMember = (cohortId, userName, userId) => dispatch =>
   patchData(`/api/cohorts/${cohortId}/remove-member`, {

--- a/client/src/modules/cohort/model/actions.js
+++ b/client/src/modules/cohort/model/actions.js
@@ -158,6 +158,9 @@ export const createCohort = data => dispatch =>
       });
     });
 
+export const createOrUpdateCohortOnAddingNewMemberWS = data => dispatch =>
+  dispatch(createCohortSuccess(data));
+
 export const fetchCohortsMetaData = () => dispatch =>
   getData('/api/cohorts/meta-data')
     .then(resp => resp.json())

--- a/client/src/modules/cohort/model/reducer.js
+++ b/client/src/modules/cohort/model/reducer.js
@@ -53,7 +53,7 @@ const membersReducer = (state = {}, action) => {
 const cohorts = (state = {}, action) => {
   switch (action.type) {
     case CohortActionTypes.CREATE_SUCCESS:
-      return { [action.payload._id]: { ...action.payload }, ...state };
+      return { ...state, [action.payload._id]: { ...action.payload } };
     case CohortActionTypes.UPDATE_SUCCESS: {
       const { description, cohortId, name } = action.payload;
       const prevCohort = state[cohortId];

--- a/client/src/modules/cohort/model/selectors.js
+++ b/client/src/modules/cohort/model/selectors.js
@@ -2,8 +2,15 @@ import _filter from 'lodash/filter';
 import _head from 'lodash/head';
 import _keyBy from 'lodash/keyBy';
 import { createSelector } from 'reselect';
+import _orderBy from 'lodash/orderBy';
 
-export const getCohorts = state => state.cohorts;
+export const getCohorts = state =>
+  _keyBy(
+    _orderBy(state.cohorts, cohort => new Date(cohort.createdAt).getTime(), [
+      'desc'
+    ]),
+    '_id'
+  );
 
 export const getCohortDetails = (state, cohortId) => {
   const cohort = _head(

--- a/client/src/modules/list/components/Items/ItemsList.jsx
+++ b/client/src/modules/list/components/Items/ItemsList.jsx
@@ -50,7 +50,7 @@ class ItemsList extends PureComponent {
       }
     } = this.props;
 
-    this.socket.emit('leavingRoom', listId);
+    this.socket.emit('leavingListRoom', listId);
 
     // or disconnect from the socket here
   }
@@ -114,7 +114,7 @@ class ItemsList extends PureComponent {
 
     this.socket = io();
     this.socket.on('connect', () =>
-      this.socket.emit('joinRoom', `list-${listId}`)
+      this.socket.emit('joinListRoom', `list-${listId}`)
     );
   };
 

--- a/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
+++ b/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
@@ -113,7 +113,7 @@ class ListArchivedItem extends PureComponent {
 
     this.socket = io();
     this.socket.on('connect', () =>
-      this.socket.emit('joinRoom', `list-${listId}`)
+      this.socket.emit('joinListRoom', `list-${listId}`)
     );
   };
 

--- a/client/src/modules/list/components/Items/ListItem/ListItem.jsx
+++ b/client/src/modules/list/components/Items/ListItem/ListItem.jsx
@@ -67,7 +67,7 @@ class ListItem extends PureComponent {
       }
     } = this.props;
 
-    this.socket.emit('leavingRoom', listId);
+    this.socket.emit('leavingListRoom', listId);
   }
 
   handleSocketConnection = () => {
@@ -83,7 +83,7 @@ class ListItem extends PureComponent {
 
     this.socket = io();
     this.socket.on('connect', () =>
-      this.socket.emit('joinRoom', `list-${listId}`)
+      this.socket.emit('joinListRoom', `list-${listId}`)
     );
   };
 

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -81,7 +81,7 @@ class List extends Component {
     } = this.props;
 
     if (prevListId !== listId) {
-      this.socket.emit('leavingRoom', prevListId);
+      this.socket.emit('leavingListRoom', prevListId);
       this.fetchData();
     }
   }
@@ -93,7 +93,7 @@ class List extends Component {
       }
     } = this.props;
 
-    this.socket.emit('leavingRoom', listId);
+    this.socket.emit('leavingListRoom', listId);
   }
 
   handleSocketConnection = () => {
@@ -103,7 +103,7 @@ class List extends Component {
 
     this.socket = io();
     this.socket.on('connect', () =>
-      this.socket.emit('joinRoom', `list-${listId}`)
+      this.socket.emit('joinListRoom', `list-${listId}`)
     );
   };
 

--- a/server/common/utils/helpers.js
+++ b/server/common/utils/helpers.js
@@ -129,11 +129,12 @@ const responseWithCohorts = cohorts =>
   });
 
 const responseWithCohort = cohort => {
-  const { _id, description, memberIds, name, isArchived } = cohort;
+  const { _id, createdAt, description, memberIds, name, isArchived } = cohort;
   const membersCount = memberIds.length;
 
   return {
     _id,
+    createdAt,
     description,
     isArchived,
     membersCount,

--- a/server/common/utils/noOp.js
+++ b/server/common/utils/noOp.js
@@ -1,0 +1,3 @@
+const noOp = () => {};
+
+module.exports = noOp;

--- a/server/common/variables.js
+++ b/server/common/variables.js
@@ -67,9 +67,14 @@ const ItemStatusType = Object.freeze({
   FREE: 'item/FREE'
 });
 
+const CohortActionTypes = Object.freeze({
+  ADD_MEMBER_SUCCESS: 'cohort/ADD_MEMBER_SUCCESS'
+});
+
 module.exports = {
   NUMBER_OF_ACTIVITIES_TO_SEND,
   ActivityType,
+  CohortActionTypes,
   DB_URL,
   DEMO_MODE_ID,
   DEMO_USER_ID,

--- a/server/controllers/cohort.js
+++ b/server/controllers/cohort.js
@@ -50,7 +50,7 @@ const getCohortsMetaData = (req, resp) => {
   } = req;
 
   Cohort.find({ memberIds: currentUserId, isArchived: false })
-    .select('_id name description memberIds ownerIds')
+    .select('_id createdAt description memberIds name ownerIds')
     .sort({ createdAt: -1 })
     .lean()
     .exec()
@@ -74,7 +74,7 @@ const getArchivedCohortsMetaData = (req, resp) => {
       ownerIds: userId,
       isArchived: true
     },
-    '_id name description isArchived memberIds ownerIds',
+    '_id name createdAt description isArchived memberIds ownerIds',
     { sort: { created_at: -1 } }
   )
     .lean()

--- a/server/sockets/cohort.js
+++ b/server/sockets/cohort.js
@@ -1,10 +1,39 @@
 const { CohortActionTypes } = require('../common/variables');
+const Cohort = require('../models/cohort.model');
+const { responseWithCohort } = require('../common/utils');
+const noOp = require('../common/utils/noOp');
 
-const addCohortMemberWS = socket => {
+const addCohortMemberWS = (socket, clients) => {
   socket.on(CohortActionTypes.ADD_MEMBER_SUCCESS, data => {
     socket.broadcast
       .to(`cohort-${data.cohortId}`)
       .emit(CohortActionTypes.ADD_MEMBER_SUCCESS, data);
+
+    const { cohortId } = data;
+
+    if (clients.size > 0) {
+      Cohort.findById(cohortId)
+        .select('_id isArchived createdAt name description memberIds')
+        .lean()
+        .exec()
+        .then(doc => {
+          if (doc) {
+            const { memberIds } = doc;
+            const cohort = responseWithCohort(doc);
+
+            memberIds.forEach(id => {
+              const userId = id.toString();
+
+              if (clients.has(userId)) {
+                socket.broadcast
+                  .to(clients.get(userId))
+                  .emit(CohortActionTypes.ADD_MEMBER_SUCCESS, cohort);
+              }
+            });
+          }
+        })
+        .catch(noOp);
+    }
   });
 };
 

--- a/server/sockets/cohort.js
+++ b/server/sockets/cohort.js
@@ -1,0 +1,13 @@
+const { CohortActionTypes } = require('../common/variables');
+
+const addCohortMemberWS = socket => {
+  socket.on(CohortActionTypes.ADD_MEMBER_SUCCESS, data => {
+    socket.broadcast
+      .to(`cohort-${data.cohortId}`)
+      .emit(CohortActionTypes.ADD_MEMBER_SUCCESS, data);
+  });
+};
+
+module.exports = {
+  addCohortMemberWS
+};

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -49,11 +49,12 @@ const socketListenTo = server => {
     });
 
     socket.on('joinCohortRoom', room => {
+      console.log('wchodzi');
       socket.join(room);
     });
 
-    socket.on('leavingCohortRoom', listId => {
-      socket.leave(`cohort-${listId}`);
+    socket.on('leavingCohortRoom', cohortId => {
+      socket.leave(`cohort-${cohortId}`);
     });
 
     socket.on('error', () => {

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -16,6 +16,7 @@ const {
   restoreItemWS,
   updateItemState
 } = require('./list');
+const { addCohortMemberWS } = require('./cohort');
 
 const socketListenTo = server => {
   const ioInstance = io(server, { forceNew: true });
@@ -49,7 +50,6 @@ const socketListenTo = server => {
     });
 
     socket.on('joinCohortRoom', room => {
-      console.log('wchodzi');
       socket.join(room);
     });
 
@@ -70,6 +70,8 @@ const socketListenTo = server => {
     updateItemState(socket);
     deleteItemWS(socket);
     restoreItemWS(socket);
+
+    addCohortMemberWS(socket);
   });
 };
 

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -45,7 +45,15 @@ const socketListenTo = server => {
     });
 
     socket.on('leavingListRoom', listId => {
-      socket.leave(`list-${listId}`);
+      socket.leave(`cohort-${listId}`);
+    });
+
+    socket.on('joinCohortRoom', room => {
+      socket.join(room);
+    });
+
+    socket.on('leavingCohortRoom', listId => {
+      socket.leave(`cohort-${listId}`);
     });
 
     socket.on('error', () => {

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -59,13 +59,11 @@ const socketListenTo = server => {
       socket.leave(`cohort-${cohortId}`);
     });
 
-    socket.on('joinCohortsRoom', userId => {
-      socket.join('cohorts');
+    socket.on('enterCohortsView', userId => {
       cohortsClients.set(userId, socket.id);
     });
 
-    socket.on('leavingCohortsRoom', userId => {
-      socket.leave('cohorts');
+    socket.on('leavingCohortsView', userId => {
       cohortsClients.delete(userId);
     });
 

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -31,6 +31,8 @@ const socketListenTo = server => {
     })
   );
 
+  const cohortsClients = new Map();
+
   ioInstance.on('connection', socket => {
     const {
       request: { user }
@@ -57,6 +59,16 @@ const socketListenTo = server => {
       socket.leave(`cohort-${cohortId}`);
     });
 
+    socket.on('joinCohortsRoom', userId => {
+      socket.join('cohorts');
+      cohortsClients.set(userId, socket.id);
+    });
+
+    socket.on('leavingCohortsRoom', userId => {
+      socket.leave('cohorts');
+      cohortsClients.delete(userId);
+    });
+
     socket.on('error', () => {
       /* Ignore error.
        * Don't show any information to a user
@@ -71,7 +83,7 @@ const socketListenTo = server => {
     deleteItemWS(socket);
     restoreItemWS(socket);
 
-    addCohortMemberWS(socket);
+    addCohortMemberWS(socket, cohortsClients);
   });
 };
 

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -40,11 +40,11 @@ const socketListenTo = server => {
       return;
     }
 
-    socket.on('joinRoom', room => {
+    socket.on('joinListRoom', room => {
       socket.join(room);
     });
 
-    socket.on('leavingRoom', listId => {
+    socket.on('leavingListRoom', listId => {
       socket.leave(`list-${listId}`);
     });
 

--- a/server/tests/__mocks__/cohortsMock.js
+++ b/server/tests/__mocks__/cohortsMock.js
@@ -25,6 +25,7 @@ const cohortsMock = [
 
 const expectedCohortMetaDataProperties = [
   '_id',
+  'createdAt',
   'description',
   'isArchived',
   'membersCount',


### PR DESCRIPTION
On adding member to cohort 'A':
1. The user who performed the action gets all the needed data via current logic only.
2. All members of cohort 'A' who are currently on this cohort view get new Member data,
3. All members of cohort 'A' who are currently on cohorts view get updated Data of cohort 'A' (membersCount). Users who are not members of cohort 'A' and are currently on cohorts view won't get any info/data.
4. New member of cohort 'A' who is currently on cohorts view gets meta data of cohort 'A'
