### PR TITLE
[EOC-BUG] Add longer pingTimeout to prevent from disconnection

### DIFF
--- a/server/common/variables.js
+++ b/server/common/variables.js
@@ -128,6 +128,7 @@ const ListHeaderStatusTypes = Object.freeze({
 });
 
 const LOCK_TIMEOUT = 300000;
+const SOCKET_TIMEOUT = 60000;
 
 module.exports = {
   ActivityType,
@@ -144,5 +145,6 @@ module.exports = {
   ListType,
   LOCK_TIMEOUT,
   NUMBER_OF_ACTIVITIES_TO_SEND,
-  PROJECT_NAME
+  PROJECT_NAME,
+  SOCKET_TIMEOUT
 };

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -55,7 +55,7 @@ const {
 } = require('./cohort');
 
 const socketListenTo = server => {
-  const ioInstance = io(server, { forceNew: true });
+  const ioInstance = io(server, { forceNew: true, pingTimeout: 60000 });
 
   ioInstance.use(
     passportSocketIo.authorize({

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -53,9 +53,13 @@ const {
   updateCohort,
   updateCohortHeaderStatus
 } = require('./cohort');
+const { SOCKET_TIMEOUT } = require('../common/variables');
 
 const socketListenTo = server => {
-  const ioInstance = io(server, { forceNew: true, pingTimeout: 60000 });
+  const ioInstance = io(server, {
+    forceNew: true,
+    pingTimeout: SOCKET_TIMEOUT
+  });
 
   ioInstance.use(
     passportSocketIo.authorize({


### PR DESCRIPTION
This error causes those issues with Sockets that disconnects randomly on Chrome. 

![Zrzut ekranu 2019-08-7 o 12 21 53](https://user-images.githubusercontent.com/27632432/62618392-61096180-b914-11e9-9e98-cc06825739c7.png)

https://github.com/socketio/socket.io/issues/3259#issuecomment-448058937

Referring to a comment linked above, socket.io library changed default ping timeout from 60000ms in (v2.0.4) to 5000ms in (v2.1.0+), which is not enough for some browsers and they get disconnected randomly. 


Overwriting this parameter fixed the issue, at least on localhost 😄 