### PR TITLE
[EOC-390] Display important notifications on socket's events - investigation

### DIFF
--- a/client/src/app/components/Layout/Layout.jsx
+++ b/client/src/app/components/Layout/Layout.jsx
@@ -30,6 +30,7 @@ import Toolbar, { ToolbarItem } from './Toolbar';
 import { ListViewIcon, TilesViewIcon } from 'assets/images/icons';
 import { Routes, ViewType } from 'common/constants/enums';
 import Preloader from 'common/components/Preloader';
+import { enterApp } from 'sockets';
 
 export class Layout extends PureComponent {
   constructor(props) {
@@ -66,10 +67,12 @@ export class Layout extends PureComponent {
 
     if (!prevUser && currentUser) {
       const {
+        id,
         settings: { viewType }
       } = currentUser;
 
       this.handleSwitchView(viewType);
+      enterApp(id);
     }
   }
 

--- a/client/src/app/components/Layout/Toolbar/components/UserBar/UserBar.jsx
+++ b/client/src/app/components/Layout/Toolbar/components/UserBar/UserBar.jsx
@@ -13,8 +13,12 @@ import Dropdown from 'common/components/Dropdown';
 
 class UserBar extends Component {
   handleLogOut = () => {
+    const {
+      currentUser: { id }
+    } = this.props;
     const { logoutCurrentUser } = this.props;
-    logoutCurrentUser();
+
+    logoutCurrentUser(id);
   };
 
   renderAvatar = () => {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -355,5 +355,7 @@
   "activity.cohort.invite-user": "{performer} invited {user} to '{cohort}' cohort.",
   "activity.cohort.remove-user": "{performer} removed {user} from '{cohort}' cohort.",
   "activity.cohort.set-as-owner": "{performer} made {user} an owner in '{cohort}' cohort.",
-  "activity.cohort.set-as-member": "{performer} made {user} a member in '{cohort}' cohort."
+  "activity.cohort.set-as-member": "{performer} made {user} a member in '{cohort}' cohort.",
+  "notification.add-to-cohort": "{performerName} has added you to '{resourceName}' cohort.",
+  "notification.add-to-list": "{performerName} has added you to '{resourceName}' list."
 }

--- a/client/src/modules/notification/components/Notification.jsx
+++ b/client/src/modules/notification/components/Notification.jsx
@@ -7,7 +7,10 @@ import { MessageType as NotificationType } from 'common/constants/enums';
 
 const Notification = ({ data, id, redirect, type }) => (
   <MessageBox type={type}>
-    <FormattedMessage id={id} values={{ data }} />
+    <FormattedMessage
+      id={id}
+      values={typeof data === 'string' ? { data } : { ...data }}
+    />
     {type === NotificationType.ERROR && !redirect && (
       <FormattedMessage id="common.try-again" />
     )}
@@ -15,7 +18,11 @@ const Notification = ({ data, id, redirect, type }) => (
 );
 
 Notification.propTypes = {
-  data: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  data: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+    PropTypes.objectOf(PropTypes.string)
+  ]),
   id: PropTypes.string.isRequired,
   redirect: PropTypes.bool,
   type: PropTypes.string.isRequired

--- a/client/src/modules/user/model/actions.js
+++ b/client/src/modules/user/model/actions.js
@@ -9,6 +9,7 @@ import { createNotificationWithTimeout } from 'modules/notification/model/action
 import { ValidationException } from 'common/exceptions/ValidationException';
 import history from 'common/utils/history';
 import { asyncTypes, enumerable } from 'common/utils/helpers';
+import { leaveApp } from 'sockets';
 
 export const AuthorizationActionTypes = enumerable('user')(
   ...asyncTypes('FETCH'),
@@ -44,9 +45,12 @@ const updateSettingsFailure = () => ({
   type: AuthorizationActionTypes.UPDATE_SETTINGS_FAILURE
 });
 
-export const logoutCurrentUser = () => dispatch =>
+export const logoutCurrentUser = id => dispatch =>
   postRequest('/auth/logout')
-    .then(() => window.location.reload())
+    .then(() => {
+      leaveApp(id);
+      window.location.reload();
+    })
     .catch(err => dispatch(logoutFailure(err.message)));
 
 export const loginDemoUser = () => dispatch =>

--- a/client/src/sockets/enums.js
+++ b/client/src/sockets/enums.js
@@ -77,4 +77,8 @@ export const CommentEvents = Object.freeze({
   ADD_SUCCESS: CommentActionTypes.ADD_SUCCESS
 });
 
+export const NotificationEvents = Object.freeze({
+  ADD_COHORT_MEMBER: 'notification/ADD_COHORT_MEMBER';
+})
+
 export { ItemStatusType };

--- a/client/src/sockets/enums.js
+++ b/client/src/sockets/enums.js
@@ -78,7 +78,8 @@ export const CommentEvents = Object.freeze({
 });
 
 export const NotificationEvents = Object.freeze({
-  ADD_COHORT_MEMBER: 'notification/ADD_COHORT_MEMBER';
-})
+  ADD_COHORT_MEMBER: 'notification.add-to-cohort',
+  ADD_LIST_VIEWER: 'notification.add-to-list'
+});
 
 export { ItemStatusType };

--- a/client/src/sockets/helpers/index.js
+++ b/client/src/sockets/helpers/index.js
@@ -6,6 +6,8 @@ import {
   dashboardRoute
 } from 'common/utils/helpers';
 import { ListActionTypes } from '../../modules/list/model/actionTypes';
+import { MessageType as NotificationType } from 'common/constants/enums';
+import { createNotificationWithTimeout } from 'modules/notification/model/actions';
 
 export const listEventsController = (event, data, dispatch) => {
   switch (event) {
@@ -70,3 +72,9 @@ export const cohortEventsController = (event, data, dispatch) => {
       return dispatch({ type: event, payload: data });
   }
 };
+
+export const notificationEventsController = (event, data, dispatch) =>
+  createNotificationWithTimeout(dispatch, NotificationType.SUCCESS, {
+    notificationId: event,
+    data
+  });

--- a/client/src/sockets/index.js
+++ b/client/src/sockets/index.js
@@ -2,4 +2,8 @@ import io from 'socket.io-client';
 
 const socket = io({ forceNew: true });
 
+export const enterApp = userId => socket.emit('enterApp', { userId });
+
+export const leaveApp = userId => socket.emit('leaveApp', { userId });
+
 export default socket;

--- a/client/src/sockets/receiveEvents.js
+++ b/client/src/sockets/receiveEvents.js
@@ -5,9 +5,14 @@ import {
   ItemsEvents,
   ItemStatusType,
   ListEvents,
-  ListHeaderEvents
+  ListHeaderEvents,
+  NotificationEvents
 } from './enums';
-import { cohortEventsController, listEventsController } from 'sockets/helpers';
+import {
+  cohortEventsController,
+  listEventsController,
+  notificationEventsController
+} from 'sockets/helpers';
 
 export const receiveEvents = (dispatch, socket) => {
   Object.values(ItemsEvents).forEach(event =>
@@ -36,5 +41,11 @@ export const receiveEvents = (dispatch, socket) => {
 
   Object.values(CohortHeaderEvents).forEach(event =>
     socket.on(event, data => dispatch({ type: event, payload: data }))
+  );
+
+  Object.values(NotificationEvents).forEach(event =>
+    socket.on(event, data =>
+      notificationEventsController(event, data, dispatch)
+    )
   );
 };

--- a/server/common/variables.js
+++ b/server/common/variables.js
@@ -144,6 +144,11 @@ const ViewType = enumerable('viewType')('LIST', 'TILES');
 
 const BadRequestReason = enumerable('reason')('VALIDATION');
 
+const NotificationEvents = Object.freeze({
+  ADD_COHORT_MEMBER: 'notification.add-to-cohort',
+  ADD_LIST_VIEWER: 'notification.add-to-list'
+});
+
 module.exports = {
   ActivityType,
   BadRequestReason,
@@ -161,6 +166,7 @@ module.exports = {
   ListHeaderStatusTypes,
   ListType,
   LOCK_TIMEOUT,
+  NotificationEvents,
   NUMBER_OF_ACTIVITIES_TO_SEND,
   PROJECT_NAME,
   Routes,

--- a/server/controllers/cohort.js
+++ b/server/controllers/cohort.js
@@ -29,6 +29,7 @@ const allCohortsViewClients = require('../sockets/index').getAllCohortsViewClien
 const cohortClients = require('../sockets/index').getCohortViewClients();
 const dashboardClients = require('../sockets/index').getDashboardViewClients();
 const listClients = require('../sockets/index').getListViewClients();
+const onlineClients = require('../sockets/index').getOnlineClients();
 const socketInstance = require('../sockets/index').getSocketInstance();
 const socketActions = require('../sockets/cohort');
 
@@ -478,7 +479,7 @@ const removeOwnerRole = (req, resp) => {
 
 const addMember = (req, resp) => {
   const {
-    user: { _id: userId, idFromProvider }
+    user: { _id: userId, idFromProvider, displayName }
   } = req;
   const { id: cohortId } = req.params;
   const { email } = req.body;
@@ -549,15 +550,21 @@ const addMember = (req, resp) => {
         const { ownerIds } = currentCohort;
         const userToSend = responseWithCohortMember(user, ownerIds);
 
+        const notificationData = {
+          performerName: displayName,
+          resourceName: currentCohort.name
+        };
+
         return returnPayload(
           socketActions.addMember(
             socketInstance,
             allCohortsViewClients,
-            dashboardClients
+            dashboardClients,
+            onlineClients
           )({
             cohortId: sanitizedCohortId,
             member: userToSend,
-            userId
+            notificationData
           })
         )(userToSend);
       }

--- a/server/controllers/cohort.js
+++ b/server/controllers/cohort.js
@@ -555,8 +555,9 @@ const addMember = (req, resp) => {
             allCohortsViewClients,
             dashboardClients
           )({
-            cohortId,
-            member: userToSend
+            cohortId: sanitizedCohortId,
+            member: userToSend,
+            userId
           })
         )(userToSend);
       }

--- a/server/controllers/list.js
+++ b/server/controllers/list.js
@@ -34,6 +34,7 @@ const cohortClients = require('../sockets/index').getCohortViewClients();
 const dashboardClients = require('../sockets/index').getDashboardViewClients();
 const listClients = require('../sockets/index').getListViewClients();
 const socketInstance = require('../sockets/index').getSocketInstance();
+const onlineClients = require('../sockets/index').getOnlineClients();
 const { createListCohort } = require('../sockets/cohort');
 const socketActions = require('../sockets/list');
 
@@ -1015,7 +1016,7 @@ const removeMemberRole = (req, resp) => {
 
 const addViewer = (req, resp) => {
   const {
-    user: { _id: currentUserId, idFromProvider }
+    user: { _id: currentUserId, displayName, idFromProvider }
   } = req;
   const { id: listId } = req.params;
   const { email } = req.body;
@@ -1077,13 +1078,20 @@ const addViewer = (req, resp) => {
       if (user) {
         userToSend = responseWithListMember(user, cohortMembers);
 
+        const notificationData = {
+          performerName: displayName,
+          resourceName: list.name
+        };
+
         return socketActions.addListViewer(
           socketInstance,
           dashboardClients,
-          cohortClients
+          cohortClients,
+          onlineClients
         )({
-          ...userToSend,
-          listId
+          userToSend,
+          listId,
+          notificationData
         });
       }
     })

--- a/server/sockets/cohort.js
+++ b/server/sockets/cohort.js
@@ -32,8 +32,18 @@ const List = require('../models/list.model');
 const addMember = (io, allCohortsClients, dashboardClients) => data => {
   const {
     cohortId,
-    member: { _id: userId }
+    member: { _id: userId },
+    userId: performerId
   } = data;
+
+  if (dashboardClients.has(userId)) {
+    const { socketId } = dashboardClients;
+    io.sockets.to(socketId).emit('notification/ADD_COHORT_MEMBER', {
+      performerId,
+      userId,
+      cohortId
+    });
+  }
 
   io.sockets
     .to(cohortChannel(cohortId))

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -23,11 +23,13 @@ const listViewClients = new Map();
 const cohortClientLocks = new Map();
 const itemClientLocks = new Map();
 const listClientLocks = new Map();
+const onlineClients = new Map();
 
 const getCohortViewClients = () => cohortViewClients;
 const getAllCohortsViewClients = () => allCohortsViewClients;
 const getDashboardViewClients = () => dashboardViewClients;
 const getListViewClients = () => listViewClients;
+const getOnlineClients = () => onlineClients;
 
 const initSocket = server => {
   socketInstance = io(server, {
@@ -125,6 +127,12 @@ const socketListeners = socketInstance => {
       }
     });
 
+    socket.on('enterApp', ({ userId }) =>
+      onlineClients.set(userId, { socketId: socket.id })
+    );
+
+    socket.on('leaveApp', ({ userId }) => onlineClients.delete(userId));
+
     socket.on('error', () => {
       /* Ignore error.
        * Don't show any information to a user
@@ -147,6 +155,7 @@ module.exports = {
   getCohortViewClients,
   getDashboardViewClients,
   getListViewClients,
+  getOnlineClients,
   getSocketInstance,
   init: initSocket,
   listen: socketListeners


### PR DESCRIPTION
### ### This is draft PR which is the only investigation about how could we implement displaying some notifications via sockets

To display a notification to the user I decided to store all users Ids with its’ sockets in a Map. It is necessary to have an additional map for all online clients because we want to display notifications even if a user is on 'profile', 'privacy policy' or 'about' view. Maybe we should replace all those previous Maps by this new one but in case of sending various data to various view, I think it will be easier to use a specific Map of clients. 

I created methods `joinApp` and `leaveApp` to save `userId` with related `socketId` on Login and Logout. 

I created new message ids in locales file and I used them as notification events names. We can't use previous cohort's or list's action types because in notifications case we will use different data there. Use of message ids caused that notification events handler can be very simple.

This example applies to functionalities: 'add a member to cohort' and 'add a viewer to list'. I pass resource's (cohort's or list's) name and action performer's name from a specific controller to the appropriate `socket' method which sends events to the client. These properties are necessary to display clearly notification. And in this method, I send 'notification event to the user to whom the action applies.

![notifications](https://user-images.githubusercontent.com/25374390/64230192-62ff1a00-ceec-11e9-9289-2bdc1e5ff361.gif)
