### PR TITLE
[EOC-367] Fix member details box size

### DIFF
--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -2,7 +2,6 @@ import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 import { RouterMatchPropType, UserPropType } from 'common/constants/propTypes';

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -445,11 +445,7 @@ class MemberDetails extends PureComponent {
 
     return (
       <Fragment>
-        <div
-          className={classNames('member-details', {
-            'member-details--flexible': !isCurrentUserAnOwner
-          })}
-        >
+        <div className="member-details">
           <button
             className="member-details__close"
             onClick={onClose}

--- a/client/src/common/components/Members/components/MemberDetails.scss
+++ b/client/src/common/components/Members/components/MemberDetails.scss
@@ -12,11 +12,6 @@
     width: 270px;
   }
 
-  &--flexible {
-    width: auto;
-    padding-right: 36px;
-  }
-
   &__close {
     position: absolute;
     top: 0;
@@ -51,7 +46,6 @@
   &__options {
     display: flex;
     flex-direction: column;
-    padding: 15px 0 0;
   }
 
   &__preloader {

--- a/client/src/common/components/Members/components/MemberDetailsHeader.scss
+++ b/client/src/common/components/Members/components/MemberDetailsHeader.scss
@@ -3,6 +3,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  margin-bottom: four-by(4);
 
   &__avatar {
     position: relative;


### PR DESCRIPTION
I have noticed that this bug appears only on the lists where I wasn't the owner.
Now it's fixed and looks the same on every view and device. Tested on Chrome, Mozilla and Safari.


<img width="444" alt="Zrzut ekranu 2019-09-6 o 10 34 24" src="https://user-images.githubusercontent.com/27632432/64413900-b4490e00-d092-11e9-8b09-47a46e8d141f.png">
<img width="452" alt="Zrzut ekranu 2019-09-6 o 10 33 56" src="https://user-images.githubusercontent.com/27632432/64413901-b4490e00-d092-11e9-8697-5cf2e855599c.png">
<img width="461" alt="Zrzut ekranu 2019-09-6 o 10 29 24" src="https://user-images.githubusercontent.com/27632432/64413902-b4490e00-d092-11e9-9204-12b00ebbb8d2.png">
<img width="440" alt="dfsgdsgwer" src="https://user-images.githubusercontent.com/27632432/64413903-b4e1a480-d092-11e9-93b3-d93d77625121.png">
<img width="556" alt="sdadas" src="https://user-images.githubusercontent.com/27632432/64413905-b4e1a480-d092-11e9-9a8e-b9b29a95ebcd.png">
