### PR TITLE
[EOC-463] Associate socket id with the session id.

### DIFF
--- a/server/models/session.model.js
+++ b/server/models/session.model.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const SessionSchema = new Schema(
+  {
+    _id: { type: String },
+    expires: { type: Date },
+    session: { type: String },
+    socketId: { type: String }
+  },
+  { collection: 'sessions' }
+);
+
+module.exports = mongoose.model('Session', SessionSchema);

--- a/server/sockets/helpers/index.js
+++ b/server/sockets/helpers/index.js
@@ -1,5 +1,6 @@
 const Cohort = require('../../models/cohort.model');
 const List = require('../../models/list.model');
+const Session = require('../../models/session.model');
 const {
   ListActionTypes,
   CohortActionTypes
@@ -222,7 +223,21 @@ const updateListOnDashboardAndCohortView = io => (
   });
 };
 
+const associateSocketWithSession = socket => {
+  const {
+    request: { sessionID },
+    id: socketId
+  } = socket;
+
+  Session.findOneAndUpdate({ _id: sessionID.toString() }, { socketId })
+    .exec()
+    .catch(() => {
+      // Ignore error
+    });
+};
+
 module.exports = {
+  associateSocketWithSession,
   cohortChannel,
   delayedUnlock,
   descriptionLockId,

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -10,6 +10,7 @@ const { updateItemState, updateListHeaderState } = require('./list');
 const { updateCohortHeaderStatus } = require('./cohort');
 const { SOCKET_TIMEOUT } = require('../common/variables');
 const { Routes } = require('../common/variables');
+const { associateSocketWithSession } = require('./helpers');
 
 const sessionStore = new MongoStore({
   mongooseConnection: mongoose.connection
@@ -64,6 +65,8 @@ const socketListeners = socketInstance => {
     if (!userExist) {
       return;
     }
+
+    associateSocketWithSession(socket);
 
     socket.on('joinRoom', ({ data, room }) => {
       const { roomId, userId, viewId } = data;


### PR DESCRIPTION
I didn't use global express.js middleware because in request there is no access to socketId.

I had access to request in socket, but this request doesn't have information about the session's store.

Session document is created automatically by connect-mongo library and _id of this document is saved as a string, not as an ObjectId.
To save additional data in the session's document (socketId) I created Schema Session and declared _id as a string. Without this Monoose couldn't match and update sessions documents.