### PR TITLE
[EOC-464] Joining and leaving rooms for all available resources on entering or exiting the app.

### DIFF
--- a/client/src/app/components/Layout/Layout.jsx
+++ b/client/src/app/components/Layout/Layout.jsx
@@ -31,6 +31,7 @@ import { ListViewIcon, TilesViewIcon } from 'assets/images/icons';
 import { Routes, ViewType } from 'common/constants/enums';
 import Preloader from 'common/components/Preloader';
 import { loadSettings, saveSettings } from 'common/utils/localStorage';
+import { clearMetaDataSuccess } from 'common/model/actions';
 
 export class Layout extends PureComponent {
   constructor(props) {
@@ -64,6 +65,20 @@ export class Layout extends PureComponent {
     if (settings) {
       const { viewType } = settings;
       this.setState({ viewType });
+    }
+  }
+
+  componentDidUpdate(previousProps) {
+    const {
+      clearMetaDataSuccess,
+      location: { pathname }
+    } = this.props;
+    const {
+      location: { previousPathname }
+    } = previousProps;
+
+    if (previousPathname !== pathname) {
+      clearMetaDataSuccess();
     }
   }
 
@@ -200,6 +215,7 @@ Layout.propTypes = {
     pathname: PropTypes.string.isRequired
   }),
 
+  clearMetaDataSuccess: PropTypes.func.isRequired,
   getLoggedUser: PropTypes.func.isRequired
 };
 
@@ -212,6 +228,6 @@ export default _flowRight(
   withRouter,
   connect(
     mapStateToProps,
-    { getLoggedUser }
+    { clearMetaDataSuccess, getLoggedUser }
   )
 )(Layout);

--- a/client/src/app/model/middleware.js
+++ b/client/src/app/model/middleware.js
@@ -1,0 +1,17 @@
+export const preventDispatchForPerformer = store => next => action => {
+  if (action.payload) {
+    const {
+      payload: { performerId, ...rest },
+      type
+    } = action;
+    const { currentUser: user } = store.getState();
+
+    if (user && performerId === user.id) {
+      return;
+    }
+
+    return next({ type, payload: { ...rest } });
+  }
+
+  return next(action);
+};

--- a/client/src/app/model/middleware.js
+++ b/client/src/app/model/middleware.js
@@ -1,16 +1,22 @@
 export const preventDispatchForPerformer = store => next => action => {
-  if (action.payload) {
-    const {
-      payload: { performerId, ...rest },
-      type
-    } = action;
-    const { currentUser: user } = store.getState();
+  if (typeof action !== 'function') {
+    const { payload } = action;
+    if (typeof payload === 'object') {
+      const {
+        payload: { performerId, ...rest },
+        type
+      } = action;
+      const { currentUser: user } = store.getState();
 
-    if (user && performerId === user.id) {
-      return;
+      if (user && performerId && performerId === user.id) {
+        return;
+      }
+
+      return next({
+        type,
+        payload: { ...rest }
+      });
     }
-
-    return next({ type, payload: { ...rest } });
   }
 
   return next(action);

--- a/client/src/app/model/middleware.js
+++ b/client/src/app/model/middleware.js
@@ -1,23 +1,23 @@
 export const preventDispatchForPerformer = store => next => action => {
-  if (typeof action !== 'function') {
-    const { payload } = action;
-    if (typeof payload === 'object') {
-      const {
-        payload: { performerId, ...rest },
-        type
-      } = action;
-      const { currentUser: user } = store.getState();
-
-      if (user && performerId && performerId === user.id) {
-        return;
-      }
-
-      return next({
-        type,
-        payload: { ...rest }
-      });
-    }
+  if (typeof action === 'function') {
+    return next(action);
   }
+  const { payload } = action;
 
-  return next(action);
+  if (typeof payload === 'object') {
+    const {
+      payload: { performerId, ...rest },
+      type
+    } = action;
+    const { currentUser } = store.getState();
+
+    if (currentUser && performerId && performerId === currentUser.id) {
+      return;
+    }
+
+    return next({
+      type,
+      payload: { ...rest }
+    });
+  }
 };

--- a/client/src/app/model/store.js
+++ b/client/src/app/model/store.js
@@ -3,8 +3,12 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
 
 import rootReducer from './reducer';
+import { preventDispatchForPerformer } from './middleware';
 
 const configureStore = () =>
-  createStore(rootReducer, composeWithDevTools(applyMiddleware(thunk)));
+  createStore(
+    rootReducer,
+    composeWithDevTools(applyMiddleware(preventDispatchForPerformer, thunk))
+  );
 
 export default configureStore;

--- a/client/src/common/model/actions.js
+++ b/client/src/common/model/actions.js
@@ -1,16 +1,15 @@
 import socket from 'sockets';
 import { CommonActionTypes } from 'common/model/actionTypes';
 
-const clearMetaDataSuccess = view => ({
-  type: CommonActionTypes.LEAVE_VIEW,
-  payload: view
+export const clearMetaDataSuccess = () => ({
+  type: CommonActionTypes.LEAVE_VIEW
 });
 
 export const enterView = (route, userId) => dispatch =>
   socket.emit('enterView', { userId, view: route });
 
 export const leaveView = (route, userId) => dispatch => {
-  dispatch(clearMetaDataSuccess(route));
+  dispatch(clearMetaDataSuccess());
   socket.emit('leaveView', { userId, view: route });
 };
 
@@ -25,5 +24,5 @@ export const leaveRoom = (route, id, userId) => dispatch => {
 
   socket.emit('leaveRoom', { data, room: route });
 
-  dispatch(clearMetaDataSuccess(route));
+  dispatch(clearMetaDataSuccess());
 };

--- a/client/src/modules/cohort/model/reducer.js
+++ b/client/src/modules/cohort/model/reducer.js
@@ -4,7 +4,6 @@ import _keyBy from 'lodash/keyBy';
 import { CohortActionTypes, CohortHeaderStatusTypes } from './actionTypes';
 import { filterDefined } from 'common/utils/helpers';
 import { CommonActionTypes } from 'common/model/actionTypes';
-import { Routes } from 'common/constants/enums';
 
 const membersReducer = (state = {}, action) => {
   switch (action.type) {
@@ -131,13 +130,7 @@ const cohorts = (state = {}, action) => {
       return { ...state, [cohortId]: cohort };
     }
     case CommonActionTypes.LEAVE_VIEW: {
-      const { payload } = action;
-
-      if (payload === Routes.COHORTS) {
-        return {};
-      }
-
-      return state;
+      return {};
     }
 
     case CohortHeaderStatusTypes.LOCK:

--- a/client/src/modules/list/model/reducer.js
+++ b/client/src/modules/list/model/reducer.js
@@ -12,7 +12,6 @@ import items from 'modules/list/components/Items/model/reducer';
 import { ListType } from 'modules/list/consts';
 import { filterDefined } from 'common/utils/helpers';
 import { CommonActionTypes } from 'common/model/actionTypes';
-import { Routes } from 'common/constants/enums';
 
 const membersReducer = (state = {}, action) => {
   switch (action.type) {
@@ -252,13 +251,7 @@ const lists = (state = {}, action) => {
       };
     }
     case CommonActionTypes.LEAVE_VIEW: {
-      const { payload } = action;
-
-      if (payload === Routes.DASHBOARD || payload === Routes.COHORT) {
-        return {};
-      }
-
-      return state;
+      return {};
     }
 
     case CohortActionTypes.ARCHIVE_SUCCESS:

--- a/server/controllers/cohort.js
+++ b/server/controllers/cohort.js
@@ -131,7 +131,7 @@ const updateCohortById = (req, resp) => {
         return resp.sendStatus(400);
       }
 
-      const data = { cohortId, description };
+      const data = { cohortId, description, performerId: userId };
 
       if (isDefined(description)) {
         const { description: prevDescription } = doc;

--- a/server/sockets/helpers/index.js
+++ b/server/sockets/helpers/index.js
@@ -85,9 +85,9 @@ const cohortChannel = cohortId => `cohort-${cohortId}`;
 
 const listChannel = listId => `sack-${listId}`;
 
-const listMetaDataChannel = listId => `${listChannel(listId)}-metadata`;
+const listMetaDataChannel = listId => `sack-meta-data-${listId}`;
 
-const cohortMetaDataChannel = cohortId => `${cohortChannel(cohortId)}-metadata`;
+const cohortMetaDataChannel = cohortId => `cohort-meta-data-${cohortId}`;
 
 const handleLocks = (model, query) => ({ description, name }) =>
   model

--- a/server/sockets/helpers/index.js
+++ b/server/sockets/helpers/index.js
@@ -85,6 +85,10 @@ const cohortChannel = cohortId => `cohort-${cohortId}`;
 
 const listChannel = listId => `sack-${listId}`;
 
+const listMetaDataChannel = listId => `${listChannel(listId)}-metadata`;
+
+const cohortMetaDataChannel = cohortId => `${cohortChannel(cohortId)}-metadata`;
+
 const handleLocks = (model, query) => ({ description, name }) =>
   model
     .findOne(query)
@@ -223,32 +227,71 @@ const updateListOnDashboardAndCohortView = io => (
   });
 };
 
-const associateSocketWithSession = socket => {
+const associateSocketWithSession = async socket => {
   const {
     request: { sessionID },
     id: socketId
   } = socket;
 
-  Session.findOneAndUpdate({ _id: sessionID.toString() }, { socketId })
-    .exec()
-    .catch(() => {
-      // Ignore error
-    });
+  try {
+    await Session.findOneAndUpdate(
+      { _id: sessionID.toString() },
+      { socketId }
+    ).exec();
+  } catch {
+    // Ignore error
+  }
+};
+
+const joinMetaDataRooms = async socket => {
+  const {
+    request: {
+      user: { _id: userId }
+    }
+  } = socket;
+
+  try {
+    const lists = await List.find(
+      { viewersIds: userId, isDeleted: false },
+      '_id'
+    )
+      .lean()
+      .exec();
+
+    lists.forEach(list => socket.join(listMetaDataChannel(list._id)));
+
+    const cohorts = await Cohort.find(
+      {
+        memberIds: userId,
+        isDeleted: false
+      },
+      '_id'
+    )
+      .lean()
+      .exec();
+
+    cohorts.forEach(cohort => socket.join(cohortMetaDataChannel(cohort._id)));
+  } catch {
+    // Ignore error
+  }
 };
 
 module.exports = {
   associateSocketWithSession,
   cohortChannel,
+  cohortMetaDataChannel,
   delayedUnlock,
   descriptionLockId,
   emitCohortMetaData,
-  updateListOnDashboardAndCohortView,
   emitRoleChange,
   getListIdsByViewers,
   getListsDataByViewers,
   handleItemLocks,
   handleLocks,
+  joinMetaDataRooms,
   listChannel,
+  listMetaDataChannel,
   nameLockId,
+  updateListOnDashboardAndCohortView,
   votingBroadcast
 };

--- a/server/sockets/index.js
+++ b/server/sockets/index.js
@@ -10,7 +10,7 @@ const { updateItemState, updateListHeaderState } = require('./list');
 const { updateCohortHeaderStatus } = require('./cohort');
 const { SOCKET_TIMEOUT } = require('../common/variables');
 const { Routes } = require('../common/variables');
-const { associateSocketWithSession } = require('./helpers');
+const { associateSocketWithSession, joinMetaDataRooms } = require('./helpers');
 
 const sessionStore = new MongoStore({
   mongooseConnection: mongoose.connection
@@ -56,7 +56,7 @@ const getSocketInstance = () => {
 };
 
 const socketListeners = socketInstance => {
-  socketInstance.on('connection', socket => {
+  socketInstance.on('connection', async socket => {
     const {
       request: { user }
     } = socket;
@@ -66,7 +66,8 @@ const socketListeners = socketInstance => {
       return;
     }
 
-    associateSocketWithSession(socket);
+    await associateSocketWithSession(socket);
+    await joinMetaDataRooms(socket);
 
     socket.on('joinRoom', ({ data, room }) => {
       const { roomId, userId, viewId } = data;


### PR DESCRIPTION
1. On entering the app, on socket connection, the user joins all metadata rooms for resources he has access to.
2. To test if joining works I refactor updateCohort to emit data for new cohort meta-data room. 
3. To prevent dispatching an action twice for a user who performed this action I create redux middleware which prevents dispatching an action if the user's id is the same as the performer's id.
4. To clear unnecessary data that the user gets on views like 'about' or 'privacy policy' I check for changing the route in layout component and clear lists or cohorts data if that change occurs. I tried to not saving unnecessary data but logic was complicated. I had to compare the current route (we have no access to react-router outside of component) with event type to decide if that data has to be saved or not.
5. Leaving rooms on exiting an app is unnecessary because: "Upon disconnection, sockets leave all the channels they were part of automatically, and no special teardown is needed on your part." [docs](https://socket.io/docs/rooms-and-namespaces/)