### PR TITLE
[EOC-488] Set new password form is not displaying user name

### DIFF
--- a/client/src/modules/user/AuthBox/components/LinkExpired.scss
+++ b/client/src/modules/user/AuthBox/components/LinkExpired.scss
@@ -22,10 +22,6 @@
     width: 60%;
   }
 
-  @include breakpoint($large) {
-    width: 50%;
-  }
-
   &__heading {
     margin-bottom: four-by(4);
   }

--- a/client/src/modules/user/AuthBox/components/LinkExpired.scss
+++ b/client/src/modules/user/AuthBox/components/LinkExpired.scss
@@ -8,12 +8,22 @@
   box-shadow: 0 1px 3px rgba($shadow-color, 0.15);
   text-align: center;
   flex-direction: column;
-  width: 250px;
+  width: 90%;
+  max-width: 900px;
   align-items: center;
   padding: four-by(8);
+  box-sizing: border-box;
 
-  @include breakpoint($xsmall) {
-    width: 300px;
+  @include breakpoint($small) {
+    width: 70%;
+  }
+
+  @include breakpoint($medium) {
+    width: 60%;
+  }
+
+  @include breakpoint($large) {
+    width: 50%;
   }
 
   &__heading {

--- a/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
+++ b/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
@@ -188,7 +188,7 @@ class PasswordRecoveryForm extends PureComponent {
           {userName ? (
             <FormattedMessage
               id="user.auth.pass-recovery-form.heading-user-name"
-              values={{ name: userName, email }}
+              values={{ name: userName, email: <em title={email}>{email}</em> }}
             />
           ) : (
             <FormattedMessage id="user.auth.pass-recovery-form.heading" />

--- a/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.scss
+++ b/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.scss
@@ -4,12 +4,24 @@
   left: 50%;
   transform: translate(-50%, -50%);
   margin: 0 auto;
-  width: 350px;
+  width: 90%;
+  max-width: 900px;
   background: #fff;
   filter: drop-shadow(0 2px 2px $gray2);
-
   display: flex;
   flex-direction: column;
+
+  @include breakpoint($small) {
+    width: 70%;
+  }
+
+  @include breakpoint($medium) {
+    width: 60%;
+  }
+
+  @include breakpoint($large) {
+    width: 50%;
+  }
 
   &__heading {
     font-size: $xl-font;
@@ -19,6 +31,18 @@
     text-transform: uppercase;
     border-bottom: 1px solid $border-color;
     line-height: 1.3;
+
+    em {
+      display: inline-block;
+      text-transform: lowercase;
+      font-style: normal;
+      font-size: $l-font;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: sub;
+      max-width: 90%;
+    }
   }
 
   &__label {

--- a/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.scss
+++ b/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.scss
@@ -24,7 +24,7 @@
   }
 
   &__heading {
-    font-size: $xl-font;
+    font-size: $m-font;
     color: $text-normal;
     text-align: center;
     padding: four-by(2) four-by(4);
@@ -32,16 +32,28 @@
     border-bottom: 1px solid $border-color;
     line-height: 1.3;
 
+    @include breakpoint($small) {
+      font-size: $l-font;
+    }
+
+    @include breakpoint($large) {
+      font-size: $xl-font;
+    }
+
     em {
       display: inline-block;
       text-transform: lowercase;
       font-style: normal;
-      font-size: $l-font;
+      font-size: $m-font;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       vertical-align: sub;
       max-width: 90%;
+
+      @include breakpoint($small) {
+        font-size: $l-font;
+      }
     }
   }
 

--- a/client/src/modules/user/AuthBox/components/ResetPassword.scss
+++ b/client/src/modules/user/AuthBox/components/ResetPassword.scss
@@ -44,12 +44,20 @@
   }
 
   &__heading {
-    font-size: $xl-font;
+    font-size: $m-font;
     color: $text-normal;
     text-align: center;
     padding: four-by(2) four-by(4);
     text-transform: uppercase;
     border-bottom: 1px solid $border-color;
+
+    @include breakpoint($small) {
+      font-size: $l-font;
+    }
+
+    @include breakpoint($large) {
+      font-size: $xl-font;
+    }
   }
 
   &__message-error {

--- a/client/src/modules/user/AuthBox/components/ResetPassword.scss
+++ b/client/src/modules/user/AuthBox/components/ResetPassword.scss
@@ -8,7 +8,20 @@
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 350px;
+  width: 90%;
+  max-width: 900px;
+
+  @include breakpoint($small) {
+    width: 70%;
+  }
+
+  @include breakpoint($medium) {
+    width: 60%;
+  }
+
+  @include breakpoint($large) {
+    width: 50%;
+  }
 
   .error-message {
     max-width: 350px;

--- a/client/src/modules/user/AuthBox/components/SuccessMessage.scss
+++ b/client/src/modules/user/AuthBox/components/SuccessMessage.scss
@@ -8,14 +8,23 @@
   box-shadow: 0 1px 3px rgba($shadow-color, 0.15);
   text-align: center;
   flex-direction: column;
-  width: 250px;
+  width: 90%;
+  max-width: 900px;
   align-items: center;
   padding: four-by(8);
+  box-sizing: border-box;
 
-  @include breakpoint($xsmall) {
-    width: 300px;
+  @include breakpoint($small) {
+    width: 70%;
   }
 
+  @include breakpoint($medium) {
+    width: 60%;
+  }
+
+  @include breakpoint($large) {
+    width: 50%;
+  }
   &__heading {
     margin-bottom: four-by(4);
   }

--- a/client/src/modules/user/AuthBox/components/SuccessMessage.scss
+++ b/client/src/modules/user/AuthBox/components/SuccessMessage.scss
@@ -22,9 +22,6 @@
     width: 60%;
   }
 
-  @include breakpoint($large) {
-    width: 50%;
-  }
   &__heading {
     margin-bottom: four-by(4);
   }


### PR DESCRIPTION
I could not reproduce this error. I checked locally on the dev server, on mobile and always user name and email was displayed. But I found display error:
![Screenshot 2019-09-16_08-47-56-872](https://user-images.githubusercontent.com/25374390/64941367-bc5d3680-d866-11e9-9aed-1f5362f340f8.png)
To fix this I changed styles of the password-recovery-form component: removed fixed-width to make it more responsive and added ellipsis if the user's email address is very long and change font-size on smaller screens.

![Screenshot 2019-09-16_10-17-27-904](https://user-images.githubusercontent.com/25374390/64943555-570c4400-d86c-11e9-945c-b917432b51db.png)
![Screenshot 2019-09-16_10-18-02-330](https://user-images.githubusercontent.com/25374390/64943568-5d9abb80-d86c-11e9-93f3-9f80cb94481e.png)
![Screenshot 2019-09-16_10-18-24-301](https://user-images.githubusercontent.com/25374390/64943570-5f647f00-d86c-11e9-90c3-025b1fb93d2f.png)

To maintain greater uniformity I change the width styles in all the components in this series: `LinkExpired`, `PasswordRecoveryForm`, `ResetPassword` and `SucessMessage`.

![Screenshot 2019-09-16_10-02-50-575](https://user-images.githubusercontent.com/25374390/64942410-40b0b900-d869-11e9-95de-8188885c2817.png)
![Screenshot 2019-09-16_10-03-11-851](https://user-images.githubusercontent.com/25374390/64942412-427a7c80-d869-11e9-8e3b-5711f74d87fb.png)

