### PR TITLE
[EOC-486] Moving item between lists ( move to option) fix

### DIFF
--- a/client/src/modules/list/model/reducer.js
+++ b/client/src/modules/list/model/reducer.js
@@ -300,12 +300,17 @@ const lists = (state = {}, action) => {
       const {
         payload: { listId }
       } = action;
-      const { items: previousItems } = state[listId];
 
-      return {
-        ...state,
-        [listId]: { ...state[listId], items: items(previousItems, action) }
-      };
+      if (state[listId]) {
+        const { items: previousItems } = state[listId];
+
+        return {
+          ...state,
+          [listId]: { ...state[listId], items: items(previousItems, action) }
+        };
+      }
+
+      return state;
     }
     case ListHeaderStatusType.LOCK:
     case ListHeaderStatusType.UNLOCK: {

--- a/server/sockets/list.js
+++ b/server/sockets/list.js
@@ -750,7 +750,7 @@ const moveToList = (
   io.sockets
     .to(listChannel(sourceListId))
     .emit(ItemActionTypes.DELETE_SUCCESS, {
-      sourceListId,
+      listId: sourceListId,
       itemId: sourceItemId
     });
 


### PR DESCRIPTION
Item wasn't removed via socket because of sending invalid data name: `sourceListId` instead of `listId` and frontend didn't recognize it.