### PR TITLE
[EOC-429] Cannot edit the name after the creates "Sacks" and "Cohorts" when user enter whitespace in name field

### DIFF
--- a/client/src/common/components/FormDialog.jsx
+++ b/client/src/common/components/FormDialog.jsx
@@ -41,7 +41,11 @@ class FormDialog extends Component {
     }
   };
 
-  handleDescriptionChange = description => this.setState({ description });
+  handleDescriptionChange = value => {
+    const description = _trim(value) === '' ? '' : value;
+
+    this.setState({ description });
+  };
 
   handleNameChange = name => this.setState({ name }, this.validateName);
 


### PR DESCRIPTION
 I couldn't save a cohort or sack when I entered whitespaces in the name field. We validate name field and we don't allow to save name with whitespaces only.

But there was an analogical situation with the description field. The user could save cohort with the description with whitespaces only.

Because the description field is optional I don't display any warnings but replace string with whitespaces only with an empty string. 