### PR TITLE
[EOC-520] Remove user account refactor controllers to check if display name exist

### DIFF
--- a/client/src/app/components/Layout/Toolbar/components/UserBar/UserBar.jsx
+++ b/client/src/app/components/Layout/Toolbar/components/UserBar/UserBar.jsx
@@ -2,15 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import _flowRight from 'lodash/flowRight';
 
 import { logoutCurrentUser } from 'modules/user/model/actions';
 import { getCurrentUser } from 'modules/user/model/selectors';
-import { UserPropType } from 'common/constants/propTypes';
+import { IntlPropType, UserPropType } from 'common/constants/propTypes';
 import { LogoutIcon, UserIcon, CohortIcon } from 'assets/images/icons';
 import Avatar from 'common/components/Avatar';
 import Dropdown from 'common/components/Dropdown';
 import './UserBar.scss';
+import { formatName } from 'common/utils/helpers';
 
 class UserBar extends Component {
   handleLogOut = () => {
@@ -20,27 +22,35 @@ class UserBar extends Component {
 
   renderAvatar = () => {
     const {
-      currentUser: { avatarUrl, name }
+      currentUser: { avatarUrl, name },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
-      <Avatar avatarUrl={avatarUrl} className="user-bar__avatar" name={name} />
+      <Avatar
+        avatarUrl={avatarUrl}
+        className="user-bar__avatar"
+        name={formattedName}
+      />
     );
   };
 
   renderUserBarMenu = () => {
     const {
-      currentUser: { avatarUrl, name }
+      currentUser: { avatarUrl, name },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
       <ul className="user-bar__menu">
         <li className="user-bar__menu-item">
-          {name}
+          {formattedName}
           <Avatar
             avatarUrl={avatarUrl}
             className="user-bar__avatar"
-            name={name}
+            name={formattedName}
           />
         </li>
         <li className="user-bar__menu-item">
@@ -85,6 +95,7 @@ class UserBar extends Component {
 
 UserBar.propTypes = {
   currentUser: UserPropType.isRequired,
+  intl: IntlPropType.isRequired,
 
   logoutCurrentUser: PropTypes.func.isRequired
 };
@@ -93,7 +104,10 @@ const mapStateToProps = state => ({
   currentUser: getCurrentUser(state)
 });
 
-export default connect(
-  mapStateToProps,
-  { logoutCurrentUser }
+export default _flowRight(
+  injectIntl,
+  connect(
+    mapStateToProps,
+    { logoutCurrentUser }
+  )
 )(UserBar);

--- a/client/src/common/components/Activities/components/Activity.jsx
+++ b/client/src/common/components/Activities/components/Activity.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
+import { injectIntl, FormattedMessage, FormattedRelative } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './Activity.scss';
@@ -77,7 +77,9 @@ class Activity extends PureComponent {
       intl: { formatMessage }
     } = this.props;
     const formattedName = formatName(performer.name, formatMessage);
-    const formattedUserName = formatName(editedUser.name, formatMessage);
+    const formattedUserName = editedUser
+      ? formatName(editedUser.name, formatMessage)
+      : null;
 
     return (
       <Fragment>
@@ -86,7 +88,7 @@ class Activity extends PureComponent {
           values={{
             list: <em>{this.renderListLink()}</em>,
             performer: <em>{formattedName}</em>,
-            user: editedUser ? formattedUserName : null,
+            user: formattedUserName,
             value: editedValue
           }}
         />
@@ -171,4 +173,4 @@ Activity.propTypes = {
   intl: IntlPropType.isRequired
 };
 
-export default Activity;
+export default injectIntl(Activity);

--- a/client/src/common/components/Activities/components/Activity.jsx
+++ b/client/src/common/components/Activities/components/Activity.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { injectIntl, FormattedMessage, FormattedRelative } from 'react-intl';
+import { FormattedMessage, FormattedRelative } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './Activity.scss';

--- a/client/src/common/components/Activities/components/Activity.jsx
+++ b/client/src/common/components/Activities/components/Activity.jsx
@@ -1,10 +1,12 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
+import { injectIntl, FormattedMessage, FormattedRelative } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './Activity.scss';
+import { formatName } from 'common/utils/helpers';
+import { IntlPropType } from 'common/constants/propTypes';
 
 class Activity extends PureComponent {
   renderCohortLink = () => {
@@ -37,8 +39,10 @@ class Activity extends PureComponent {
 
   renderItemActivity = () => {
     const {
-      activity: { activityType, cohort, editedValue, item, list, performer }
+      activity: { activityType, cohort, editedValue, item, list, performer },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(performer.name, formatMessage);
 
     return (
       <Fragment>
@@ -47,7 +51,7 @@ class Activity extends PureComponent {
           values={{
             item: item ? <em className="activity__item">{item.name}</em> : null,
             list: list ? <em className="activity__item">{list.name}</em> : null,
-            performer: <em>{performer.name}</em>,
+            performer: <em>{formattedName}</em>,
             value: <em>{editedValue}</em>
           }}
         />
@@ -69,8 +73,11 @@ class Activity extends PureComponent {
 
   renderListActivity = () => {
     const {
-      activity: { activityType, cohort, editedUser, editedValue, performer }
+      activity: { activityType, cohort, editedUser, editedValue, performer },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(performer.name, formatMessage);
+    const formattedUserName = formatName(editedUser.name, formatMessage);
 
     return (
       <Fragment>
@@ -78,8 +85,8 @@ class Activity extends PureComponent {
           id={activityType}
           values={{
             list: <em>{this.renderListLink()}</em>,
-            performer: <em>{performer.name}</em>,
-            user: editedUser ? editedUser.name : null,
+            performer: <em>{formattedName}</em>,
+            user: editedUser ? formattedUserName : null,
             value: editedValue
           }}
         />
@@ -95,15 +102,17 @@ class Activity extends PureComponent {
 
   renderCohortActivity = () => {
     const {
-      activity: { activityType, editedUser, editedValue, performer }
+      activity: { activityType, editedUser, editedValue, performer },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(performer.name, formatMessage);
 
     return (
       <FormattedMessage
         id={activityType}
         values={{
           cohort: <em>{this.renderCohortLink()}</em>,
-          performer: <em>{performer.name}</em>,
+          performer: <em>{formattedName}</em>,
           user: editedUser ? editedUser.name : null,
           value: editedValue
         }}
@@ -119,8 +128,10 @@ class Activity extends PureComponent {
         item,
         list,
         performer: { avatarUrl, name }
-      }
+      },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
       <div className="activity">
@@ -128,7 +139,7 @@ class Activity extends PureComponent {
           <Avatar
             avatarUrl={avatarUrl}
             className="activity__image"
-            name={name}
+            name={formattedName}
           />
         </div>
         <div className="activity__message">
@@ -156,7 +167,8 @@ Activity.propTypes = {
     item: PropTypes.objectOf(PropTypes.string),
     list: PropTypes.objectOf(PropTypes.string),
     performer: PropTypes.objectOf(PropTypes.string)
-  })
+  }),
+  intl: IntlPropType.isRequired
 };
 
 export default Activity;

--- a/client/src/common/components/Avatar.jsx
+++ b/client/src/common/components/Avatar.jsx
@@ -1,9 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { injectIntl } from 'react-intl';
 
 import { UserIcon } from 'assets/images/icons';
 import './Avatar.scss';
+import { formatName } from 'common/utils/helpers';
+import { IntlPropType } from 'common/constants/propTypes';
 
 class Avatar extends PureComponent {
   state = {
@@ -14,19 +17,25 @@ class Avatar extends PureComponent {
 
   render() {
     const { isAvatarError } = this.state;
-    const { avatarUrl, className, name } = this.props;
+    const {
+      avatarUrl,
+      className,
+      intl: { formatMessage },
+      name
+    } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
       <span className="avatar">
         {avatarUrl && !isAvatarError ? (
           <img
-            alt={`${name || 'user'} avatar`}
+            alt={`${formattedName || 'user'} avatar`}
             className={classNames(`${className} avatar__image`, {
               avatar__placeholder: isAvatarError
             })}
             onError={this.handleAvatarError}
             src={avatarUrl}
-            title={name}
+            title={formattedName}
           />
         ) : (
           <UserIcon />
@@ -39,7 +48,8 @@ class Avatar extends PureComponent {
 Avatar.propTypes = {
   avatarUrl: PropTypes.string,
   className: PropTypes.string,
+  intl: IntlPropType.isRequired,
   name: PropTypes.string
 };
 
-export default Avatar;
+export default injectIntl(Avatar);

--- a/client/src/common/components/Comments/Comment.jsx
+++ b/client/src/common/components/Comments/Comment.jsx
@@ -1,16 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Linkify from 'react-linkify';
+import { injectIntl } from 'react-intl';
 
-import { dateFromString } from 'common/utils/helpers';
+import { dateFromString, formatName } from 'common/utils/helpers';
 import Avatar from 'common/components/Avatar';
 import './Comment.scss';
+import { IntlPropType } from 'common/constants/propTypes';
 
 class Comment extends PureComponent {
   render() {
-    const { comment } = this.props;
+    const {
+      comment,
+      intl: { formatMessage }
+    } = this.props;
     const { authorName, authorAvatarUrl, createdAt, text } = comment;
     const date = dateFromString(createdAt);
+    const formattedName = formatName(authorName, formatMessage);
 
     return (
       <div className="comment">
@@ -18,11 +24,11 @@ class Comment extends PureComponent {
           <Avatar
             avatarUrl={authorAvatarUrl}
             className="comment__image"
-            name={authorName}
+            name={formattedName}
           />
         </div>
         <div className="comment__body">
-          <span className="comment__author">{authorName}</span>
+          <span className="comment__author">{formattedName}</span>
           <span className="comment__date">{date}</span>
           <Linkify
             properties={{ target: '_blank', className: 'comment__link' }}
@@ -36,7 +42,8 @@ class Comment extends PureComponent {
 }
 
 Comment.propTypes = {
-  comment: PropTypes.objectOf(PropTypes.string).isRequired
+  comment: PropTypes.objectOf(PropTypes.string).isRequired,
+  intl: IntlPropType.isRequired
 };
 
-export default Comment;
+export default injectIntl(Comment);

--- a/client/src/common/components/Members/components/MemberButton.jsx
+++ b/client/src/common/components/Members/components/MemberButton.jsx
@@ -3,18 +3,19 @@ import PropTypes from 'prop-types';
 
 import Avatar from 'common/components/Avatar';
 import './MemberButton.scss';
+import { formatUserName } from 'common/utils/helpers';
 
 const MemberButton = ({ member, onDisplayDetails }) => (
   <button
     className="member-button"
     onClick={onDisplayDetails}
-    title={member.displayName}
+    title={formatUserName(member.displayName)}
     type="button"
   >
     <Avatar
       avatarUrl={member.avatarUrl}
       className="member-button__avatar"
-      name={member.displayName}
+      name={formatUserName(member.displayName)}
     />
   </button>
 );

--- a/client/src/common/components/Members/components/MemberButton.jsx
+++ b/client/src/common/components/Members/components/MemberButton.jsx
@@ -11,20 +11,24 @@ const MemberButton = ({
   intl: { formatMessage },
   member,
   onDisplayDetails
-}) => (
-  <button
-    className="member-button"
-    onClick={onDisplayDetails}
-    title={formatName(undefined, formatMessage)}
-    type="button"
-  >
-    <Avatar
-      avatarUrl={member.avatarUrl}
-      className="member-button__avatar"
-      name={formatName(member.displayName, formatMessage)}
-    />
-  </button>
-);
+}) => {
+  const formattedName = formatName(member.displayName, formatMessage);
+
+  return (
+    <button
+      className="member-button"
+      onClick={onDisplayDetails}
+      title={formatName(undefined, formatMessage)}
+      type="button"
+    >
+      <Avatar
+        avatarUrl={member.avatarUrl}
+        className="member-button__avatar"
+        name={formattedName}
+      />
+    </button>
+  );
+};
 
 MemberButton.propTypes = {
   intl: IntlPropType.isRequired,

--- a/client/src/common/components/Members/components/MemberButton.jsx
+++ b/client/src/common/components/Members/components/MemberButton.jsx
@@ -1,30 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './MemberButton.scss';
-import { formatUserName } from 'common/utils/helpers';
+import { formatName } from 'common/utils/helpers';
+import { IntlPropType } from 'common/constants/propTypes';
 
-const MemberButton = ({ member, onDisplayDetails }) => (
+const MemberButton = ({
+  intl: { formatMessage },
+  member,
+  onDisplayDetails
+}) => (
   <button
     className="member-button"
     onClick={onDisplayDetails}
-    title={formatUserName(member.displayName)}
+    title={formatName(undefined, formatMessage)}
     type="button"
   >
     <Avatar
       avatarUrl={member.avatarUrl}
       className="member-button__avatar"
-      name={formatUserName(member.displayName)}
+      name={formatName(member.displayName, formatMessage)}
     />
   </button>
 );
 
 MemberButton.propTypes = {
+  intl: IntlPropType.isRequired,
   member: PropTypes.objectOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
   ).isRequired,
   onDisplayDetails: PropTypes.func.isRequired
 };
 
-export default MemberButton;
+export default injectIntl(MemberButton);

--- a/client/src/common/components/Members/components/MemberDetails.jsx
+++ b/client/src/common/components/Members/components/MemberDetails.jsx
@@ -28,6 +28,7 @@ import { AbortPromiseException } from 'common/exceptions/AbortPromiseException';
 import MemberDetailsHeader from './MemberDetailsHeader';
 import MemberRole from 'common/components/Members/components/MemberRole';
 import './MemberDetails.scss';
+import { formatName } from 'common/utils/helpers';
 
 const infoText = {
   [Routes.COHORT]: {
@@ -76,14 +77,14 @@ class MemberDetails extends PureComponent {
       route,
       _id: userId
     } = this.props;
-
+    const formattedName = formatName(displayName);
     const action =
       route === Routes.COHORT ? removeCohortMember : removeListMember;
 
     this.setState({ pending: true });
 
     const abortablePromise = makeAbortablePromise(
-      action(id, displayName, userId, isOwner)
+      action(id, formattedName, userId, isOwner)
     );
     this.pendingPromises.push(abortablePromise);
 
@@ -128,6 +129,7 @@ class MemberDetails extends PureComponent {
       removeOwnerRoleInCohort
     } = this.props;
     const isCurrentUserRoleChanging = currentUserId === userId;
+    const formattedUserName = formatName(displayName);
 
     this.setState({ pending: true });
 
@@ -135,11 +137,11 @@ class MemberDetails extends PureComponent {
       ? this.removeRole(
           isCurrentUserRoleChanging,
           removeOwnerRoleInCohort,
-          displayName
+          formattedUserName
         )
       : addOwnerRoleInCohort;
 
-    action(id, userId, displayName).finally(() =>
+    action(id, userId, formattedUserName).finally(() =>
       this.setState({ pending: false })
     );
   };
@@ -160,6 +162,7 @@ class MemberDetails extends PureComponent {
       removeOwnerRoleInList
     } = this.props;
     const isCurrentUserRoleChanging = currentUserId === userId;
+    const formattedName = formatName(displayName);
     let action;
 
     this.setState({ pending: true });
@@ -170,7 +173,7 @@ class MemberDetails extends PureComponent {
           ? this.removeRole(
               isCurrentUserRoleChanging,
               removeOwnerRoleInList,
-              displayName
+              formattedName
             )
           : addOwnerRoleInList;
         break;
@@ -179,7 +182,7 @@ class MemberDetails extends PureComponent {
           ? this.removeRole(
               isCurrentUserRoleChanging,
               removeMemberRoleInList,
-              displayName
+              formattedName
             )
           : addMemberRoleInList;
         break;
@@ -187,7 +190,7 @@ class MemberDetails extends PureComponent {
         break;
     }
 
-    action(id, userId, displayName).finally(() =>
+    action(id, userId, formattedName).finally(() =>
       this.setState({ pending: false })
     );
   };

--- a/client/src/common/components/Members/components/MemberDetailsHeader.jsx
+++ b/client/src/common/components/Members/components/MemberDetailsHeader.jsx
@@ -1,29 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './MemberDetailsHeader.scss';
+import { formatName } from 'common/utils/helpers';
+import { IntlPropType } from 'common/constants/propTypes';
 
-const MemberDetailsHeader = ({ avatarUrl, displayName, role }) => (
-  <header className="member-details-header">
-    <div className="member-details-header__avatar">
-      <Avatar
-        avatarUrl={avatarUrl}
-        className="member-details-header__image"
-        name={displayName}
-      />
-    </div>
-    <div>
-      <h3 className="member-details-header__name">{displayName}</h3>
-      {role}
-    </div>
-  </header>
-);
+const MemberDetailsHeader = ({
+  avatarUrl,
+  displayName,
+  intl: { formatMessage },
+  role
+}) => {
+  const formattedName = formatName(displayName, formatMessage);
+
+  return (
+    <header className="member-details-header">
+      <div className="member-details-header__avatar">
+        <Avatar
+          avatarUrl={avatarUrl}
+          className="member-details-header__image"
+          name={formattedName}
+        />
+      </div>
+      <div>
+        <h3 className="member-details-header__name">{formattedName}</h3>
+        {role}
+      </div>
+    </header>
+  );
+};
 
 MemberDetailsHeader.propTypes = {
   avatarUrl: PropTypes.string,
   displayName: PropTypes.string.isRequired,
+  intl: IntlPropType.isRequired,
   role: PropTypes.any
 };
 
-export default MemberDetailsHeader;
+export default injectIntl(MemberDetailsHeader);

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -52,6 +52,7 @@ class MembersBox extends PureComponent {
   handleAddMember = () => email => {
     const { addCohortMember, addListViewer } = this.props;
     const {
+      intl: { formatMessage },
       match: {
         params: { id }
       },
@@ -61,7 +62,7 @@ class MembersBox extends PureComponent {
     const action = route === Routes.COHORT ? addCohortMember : addListViewer;
 
     this.setState({ pending: true });
-    action(id, email).then(response => {
+    action(id, email, formatMessage).then(response => {
       if (response === UserAddingStatus.ADDED) {
         this.setState({ pending: false });
         this.hideForm();

--- a/client/src/common/components/Members/index.jsx
+++ b/client/src/common/components/Members/index.jsx
@@ -3,8 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import _flowRight from 'lodash/flowRight';
+import { injectIntl } from 'react-intl';
 
-import { RouterMatchPropType } from 'common/constants/propTypes';
+import { IntlPropType, RouterMatchPropType } from 'common/constants/propTypes';
 import { PlusIcon, DotsIcon } from 'assets/images/icons';
 import MembersForm from './components/MembersForm';
 import MemberDetails from './components/MemberDetails';
@@ -16,6 +17,7 @@ import { UserAddingStatus, MEMBERS_DISPLAY_LIMIT } from './const';
 import InviteNewUser from './components/InviteNewUser';
 import { inviteUser } from './model/actions';
 import './MembersBox.scss';
+import { formatName } from 'common/utils/helpers';
 
 class MembersBox extends PureComponent {
   constructor(props) {
@@ -128,24 +130,31 @@ class MembersBox extends PureComponent {
   };
 
   renderMemberList = () => {
-    const { members } = this.props;
+    const {
+      intl: { formatMessage },
+      members
+    } = this.props;
     const { membersDisplayLimit } = this.state;
     const membersList = Object.values(members);
 
-    return membersList.slice(0, membersDisplayLimit).map(member => (
-      <li
-        className="members-box__list-item"
-        key={member._id}
-        title={member.displayName}
-      >
-        <div className="members-box__button-mobile">
-          <MemberButton
-            member={member}
-            onDisplayDetails={this.handleDisplayingMemberDetails(member._id)}
-          />
-        </div>
-      </li>
-    ));
+    return membersList.slice(0, membersDisplayLimit).map(member => {
+      const formattedName = formatName(member.displayName, formatMessage);
+
+      return (
+        <li
+          className="members-box__list-item"
+          key={member._id}
+          title={formattedName}
+        >
+          <div className="members-box__button-mobile">
+            <MemberButton
+              member={member}
+              onDisplayDetails={this.handleDisplayingMemberDetails(member._id)}
+            />
+          </div>
+        </li>
+      );
+    });
   };
 
   renderShowMoreUsers = () => {
@@ -230,6 +239,7 @@ class MembersBox extends PureComponent {
 }
 
 MembersBox.propTypes = {
+  intl: IntlPropType.isRequired,
   isCohortList: PropTypes.bool,
   isCurrentUserAnOwner: PropTypes.bool,
   isMember: PropTypes.bool,
@@ -247,6 +257,7 @@ MembersBox.propTypes = {
 };
 
 export default _flowRight(
+  injectIntl,
   withRouter,
   connect(
     null,

--- a/client/src/common/constants/variables.js
+++ b/client/src/common/constants/variables.js
@@ -6,3 +6,4 @@ export const PENDING_DELAY = 1000;
 export const PROJECT_NAME = 'EOC';
 export const REDIRECT_TIMEOUT = 10000;
 export const DISPLAY_LIMIT = 3;
+export const USER_ANONYMOUS = 'user.anonymous';

--- a/client/src/common/utils/helpers.js
+++ b/client/src/common/utils/helpers.js
@@ -2,7 +2,7 @@ import _orderBy from 'lodash/orderBy';
 import _filter from 'lodash/filter';
 
 import { AbortPromiseException } from 'common/exceptions/AbortPromiseException';
-import { asyncPostfixes } from 'common/constants/variables';
+import { asyncPostfixes, USER_ANONYMOUS } from 'common/constants/variables';
 import { Routes, PasswordValidationValues } from 'common/constants/enums';
 
 export const makeAbortablePromise = promise => {
@@ -121,3 +121,6 @@ export const shouldAnimate = (items, item, listState) => {
 export const channel = (id, route) => `${route}-${id}`;
 
 export const metaDataChannel = (id, route) => `${route}-meta-data-${id}`;
+
+export const formatUserName = (name, formatMessage) =>
+  name || formatMessage({ id: USER_ANONYMOUS });

--- a/client/src/common/utils/helpers.js
+++ b/client/src/common/utils/helpers.js
@@ -122,5 +122,5 @@ export const channel = (id, route) => `${route}-${id}`;
 
 export const metaDataChannel = (id, route) => `${route}-meta-data-${id}`;
 
-export const formatUserName = (name, formatMessage) =>
+export const formatName = (name, formatMessage) =>
   name || formatMessage({ id: USER_ANONYMOUS });

--- a/client/src/common/utils/helpers.test.js
+++ b/client/src/common/utils/helpers.test.js
@@ -1,0 +1,26 @@
+import { formatUserName } from './helpers';
+import { USER_ANONYMOUS } from '../constants/variables';
+
+const fakeFormatMessage = () => USER_ANONYMOUS;
+
+describe('formatUserName', () => {
+  it('should return name if name is defined', () => {
+    const name = 'John Doe';
+
+    expect(formatUserName(name, fakeFormatMessage)).toEqual(name);
+  });
+
+  it('should return Anonymous if name is undefined', () => {
+    expect(formatUserName(undefined, fakeFormatMessage)).toEqual(
+      USER_ANONYMOUS
+    );
+  });
+
+  it('should return Anonymous if name is null', () => {
+    expect(formatUserName(null, fakeFormatMessage)).toEqual(USER_ANONYMOUS);
+  });
+
+  it('should return Anonymous if name is an empty string', () => {
+    expect(formatUserName('', fakeFormatMessage)).toEqual(USER_ANONYMOUS);
+  });
+});

--- a/client/src/common/utils/helpers.test.js
+++ b/client/src/common/utils/helpers.test.js
@@ -1,6 +1,11 @@
 import { formatName } from './helpers';
 import { USER_ANONYMOUS } from '../constants/variables';
 
+/**
+ * This 'fakeFormatMessage' is to simualate formatMessage
+ * function from react-intl library, because we don't have
+ * access to an instance of this function here.
+ */
 const fakeFormatMessage = () => USER_ANONYMOUS;
 
 describe('formatName', () => {

--- a/client/src/common/utils/helpers.test.js
+++ b/client/src/common/utils/helpers.test.js
@@ -1,26 +1,24 @@
-import { formatUserName } from './helpers';
+import { formatName } from './helpers';
 import { USER_ANONYMOUS } from '../constants/variables';
 
 const fakeFormatMessage = () => USER_ANONYMOUS;
 
-describe('formatUserName', () => {
+describe('formatName', () => {
   it('should return name if name is defined', () => {
     const name = 'John Doe';
 
-    expect(formatUserName(name, fakeFormatMessage)).toEqual(name);
+    expect(formatName(name, fakeFormatMessage)).toEqual(name);
   });
 
   it('should return Anonymous if name is undefined', () => {
-    expect(formatUserName(undefined, fakeFormatMessage)).toEqual(
-      USER_ANONYMOUS
-    );
+    expect(formatName(undefined, fakeFormatMessage)).toEqual(USER_ANONYMOUS);
   });
 
   it('should return Anonymous if name is null', () => {
-    expect(formatUserName(null, fakeFormatMessage)).toEqual(USER_ANONYMOUS);
+    expect(formatName(null, fakeFormatMessage)).toEqual(USER_ANONYMOUS);
   });
 
   it('should return Anonymous if name is an empty string', () => {
-    expect(formatUserName('', fakeFormatMessage)).toEqual(USER_ANONYMOUS);
+    expect(formatName('', fakeFormatMessage)).toEqual(USER_ANONYMOUS);
   });
 });

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -79,6 +79,7 @@
   "about.cta-button": "Go to app",
   "about.intro-heading": "{appName} Office inventory tracking app",
   "about.intro-subheading": "{appName} helps you track all the office inventory you need!",
+  "user.anonymous": "Anonymous",
   "user.name": "Name",
   "user.email": "Email",
   "user.password": "Password",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -223,7 +223,7 @@
   "list.list-item.move-to-confirmation": "Are you sure you want to move '{item}' item to '{list}' list?",
   "list.list-item.input-find-items": "Find items",
   "list.list-item.input-find-list": "Find list",
-  "list.list-item.edited-by": "Last edit by: {editedBy}",
+  "list.list-item.edited-by": "Last edit by: {formattedName}",
   "list.list-item.header": "Are you sure you want to archive '{name}' item?",
   "list.list-item.move-button": "Move",
   "list.list-item.move-list-button-title": "Move to {list} list",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -223,7 +223,7 @@
   "list.list-item.move-to-confirmation": "Are you sure you want to move '{item}' item to '{list}' list?",
   "list.list-item.input-find-items": "Find items",
   "list.list-item.input-find-list": "Find list",
-  "list.list-item.edited-by": "Last edit by: {formattedName}",
+  "list.list-item.edited-by": "Last edit by: {editedBy}",
   "list.list-item.header": "Are you sure you want to archive '{name}' item?",
   "list.list-item.move-button": "Move",
   "list.list-item.move-list-button-title": "Move to {list} list",

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -386,6 +386,10 @@ class Cohort extends PureComponent {
       },
       { context: dialogContextMessage, name }
     );
+    const performerFormattedName = formatName(
+      externalAction.performer,
+      formatMessage
+    );
 
     return (
       <Fragment>
@@ -515,7 +519,7 @@ class Cohort extends PureComponent {
                 values={{
                   context: dialogContextMessage,
                   name,
-                  performer: externalAction.performer
+                  performer: performerFormattedName
                 }}
               />
               {!isOwner && (

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -40,7 +40,11 @@ import Preloader from 'common/components/Preloader';
 import Breadcrumbs from 'common/components/Breadcrumbs';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import { AbortPromiseException } from 'common/exceptions/AbortPromiseException';
-import { cohortsRoute, makeAbortablePromise } from 'common/utils/helpers';
+import {
+  cohortsRoute,
+  formatName,
+  makeAbortablePromise
+} from 'common/utils/helpers';
 import { joinRoom, leaveRoom } from 'common/model/actions';
 import history from 'common/utils/history';
 
@@ -295,13 +299,15 @@ class Cohort extends PureComponent {
   handleLeave = () => {
     const {
       currentUser: { id: currentUserId, name },
+      intl: { formatMessage },
       leaveCohort,
       match: {
         params: { id }
       }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
-    return leaveCohort(id, currentUserId, name);
+    return leaveCohort(id, currentUserId, formattedName);
   };
 
   renderBreadcrumbs = () => {

--- a/client/src/modules/cohort/index.jsx
+++ b/client/src/modules/cohort/index.jsx
@@ -386,10 +386,9 @@ class Cohort extends PureComponent {
       },
       { context: dialogContextMessage, name }
     );
-    const performerFormattedName = formatName(
-      externalAction.performer,
-      formatMessage
-    );
+    const performerFormattedName = externalAction
+      ? formatName(externalAction.performer, formatMessage)
+      : null;
 
     return (
       <Fragment>

--- a/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
+++ b/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
@@ -18,6 +18,7 @@ import {
 import Confirmation from 'common/components/Confirmation';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import './ListArchivedItem.scss';
+import { formatName } from 'common/utils/helpers';
 
 class ListArchivedItem extends PureComponent {
   constructor(props) {
@@ -64,6 +65,7 @@ class ListArchivedItem extends PureComponent {
       isMember
     } = this.props;
     const { isConfirmationVisible } = this.state;
+    const formattedName = formatName(authorName, formatMessage);
 
     return (
       <li className="list-archived-item">
@@ -73,7 +75,7 @@ class ListArchivedItem extends PureComponent {
             <span className="list-archived-item__author">
               <FormattedMessage
                 id="list.list-archived-item.author"
-                values={{ authorName }}
+                values={{ authorName: formattedName }}
               />
             </span>
             <div className="list-archived-item__details">

--- a/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
+++ b/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
@@ -18,6 +18,7 @@ import {
 import Confirmation from 'common/components/Confirmation';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import './ListArchivedItem.scss';
+import { formatName } from 'common/utils/helpers';
 
 class ListArchivedItem extends PureComponent {
   constructor(props) {
@@ -32,13 +33,15 @@ class ListArchivedItem extends PureComponent {
     const {
       currentUser: { name: userName },
       data: { _id: itemId, done, name },
+      intl: { formatMessage },
       match: {
         params: { id: listId }
       },
       restoreItem
     } = this.props;
+    const formattedName = formatName(userName, formatMessage);
 
-    return restoreItem(listId, itemId, name, userName, done);
+    return restoreItem(listId, itemId, name, formattedName, done);
   };
 
   showConfirmation = () => this.setState({ isConfirmationVisible: true });

--- a/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
+++ b/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
@@ -18,7 +18,6 @@ import {
 import Confirmation from 'common/components/Confirmation';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import './ListArchivedItem.scss';
-import { formatName } from 'common/utils/helpers';
 
 class ListArchivedItem extends PureComponent {
   constructor(props) {
@@ -33,15 +32,13 @@ class ListArchivedItem extends PureComponent {
     const {
       currentUser: { name: userName },
       data: { _id: itemId, done, name },
-      intl: { formatMessage },
       match: {
         params: { id: listId }
       },
       restoreItem
     } = this.props;
-    const formattedName = formatName(userName, formatMessage);
 
-    return restoreItem(listId, itemId, name, formattedName, done);
+    return restoreItem(listId, itemId, name, userName, done);
   };
 
   showConfirmation = () => this.setState({ isConfirmationVisible: true });

--- a/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
+++ b/client/src/modules/list/components/Items/ListArchivedItem/ListArchivedItem.jsx
@@ -33,13 +33,15 @@ class ListArchivedItem extends PureComponent {
     const {
       currentUser: { name: userName },
       data: { _id: itemId, done, name },
+      intl: { formatMessage },
       match: {
         params: { id: listId }
       },
       restoreItem
     } = this.props;
+    const formattedName = formatName(userName, formatMessage);
 
-    return restoreItem(listId, itemId, name, userName, done);
+    return restoreItem(listId, itemId, name, formattedName, done);
   };
 
   showConfirmation = () => this.setState({ isConfirmationVisible: true });

--- a/client/src/modules/list/components/Items/ListItem/ListItem.jsx
+++ b/client/src/modules/list/components/Items/ListItem/ListItem.jsx
@@ -421,6 +421,7 @@ class ListItem extends PureComponent {
     const { areDetailsVisible, isNameEdited } = this.state;
     const isEdited = nameLock || descriptionLock;
     const formattedName = formatName(editedBy, formatMessage);
+    const formattedAuthorName = formatName(authorName, formatMessage);
 
     return (
       <li
@@ -457,14 +458,14 @@ class ListItem extends PureComponent {
               <span className="list-item__author">
                 <FormattedMessage
                   id="list.list-item.author"
-                  values={{ authorName }}
+                  values={{ authorName: formattedAuthorName }}
                 />
               </span>
               {editedBy && (
                 <span className="list-item__edited-by">
                   <FormattedMessage
                     id="list.list-item.edited-by"
-                    values={{ formattedName }}
+                    values={{ editedBy: formattedName }}
                   />
                 </span>
               )}

--- a/client/src/modules/list/components/Items/ListItem/ListItem.jsx
+++ b/client/src/modules/list/components/Items/ListItem/ListItem.jsx
@@ -3,11 +3,15 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import _flowRight from 'lodash/flowRight';
 
 import VotingBox from 'modules/list/components/Items/VotingBox';
-import { RouterMatchPropType, UserPropType } from 'common/constants/propTypes';
+import {
+  IntlPropType,
+  RouterMatchPropType,
+  UserPropType
+} from 'common/constants/propTypes';
 import {
   archiveItem,
   clearVote,
@@ -27,6 +31,7 @@ import ListItemDescription from '../ListItemDescription';
 import { DefaultLocks } from 'common/constants/enums';
 import MoveToListPanel from '../MoveToListPanel';
 import './ListItem.scss';
+import { formatName } from 'common/utils/helpers';
 
 class ListItem extends PureComponent {
   constructor(props) {
@@ -48,6 +53,7 @@ class ListItem extends PureComponent {
     const {
       currentUser: { name: editedBy },
       data: { _id: itemId, name: itemName, done },
+      intl: { formatMessage },
       isMember,
       markAsDone,
       markAsUnhandled,
@@ -59,10 +65,10 @@ class ListItem extends PureComponent {
     if (!isMember) {
       return;
     }
-
+    const formattedName = formatName(editedBy, formatMessage);
     const action = done ? markAsUnhandled : markAsDone;
 
-    return action(listId, itemId, itemName, editedBy).finally(
+    return action(listId, itemId, itemName, formattedName).finally(
       this.handleItemUnlock
     );
   };
@@ -133,14 +139,16 @@ class ListItem extends PureComponent {
       archiveItem,
       currentUser: { name: editedBy },
       data: { _id: itemId, name },
+      intl: { formatMessage },
       match: {
         params: { id: listId }
       }
     } = this.props;
+    const formattedName = formatName(editedBy, formatMessage);
 
     this.handleItemLock();
 
-    return archiveItem(listId, itemId, name, editedBy).finally(
+    return archiveItem(listId, itemId, name, formattedName).finally(
       this.handleItemUnlock
     );
   };
@@ -407,10 +415,12 @@ class ListItem extends PureComponent {
         locks: { name: nameLock, description: descriptionLock } = DefaultLocks,
         name
       },
+      intl: { formatMessage },
       isMember
     } = this.props;
     const { areDetailsVisible, isNameEdited } = this.state;
     const isEdited = nameLock || descriptionLock;
+    const formattedName = formatName(editedBy, formatMessage);
 
     return (
       <li
@@ -454,7 +464,7 @@ class ListItem extends PureComponent {
                 <span className="list-item__edited-by">
                   <FormattedMessage
                     id="list.list-item.edited-by"
-                    values={{ editedBy }}
+                    values={{ formattedName }}
                   />
                 </span>
               )}
@@ -491,6 +501,7 @@ ListItem.propTypes = {
       PropTypes.object
     ])
   ),
+  intl: IntlPropType.isRequired,
   isMember: PropTypes.bool,
   match: RouterMatchPropType.isRequired,
 
@@ -507,6 +518,7 @@ const mapStateToProps = state => ({
 });
 
 export default _flowRight(
+  injectIntl,
   withRouter,
   connect(
     mapStateToProps,

--- a/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
+++ b/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
@@ -310,7 +310,6 @@ ListItemDescription.propTypes = {
   itemId: PropTypes.string.isRequired,
   locked: PropTypes.bool,
   match: RouterMatchPropType.isRequired,
-  name: PropTypes.string.isRequired,
 
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,

--- a/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
+++ b/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
@@ -147,7 +147,7 @@ class ListItemDescription extends PureComponent {
       const userData = { userId, editedBy: formattedName };
 
       this.pendingPromise = makeAbortablePromise(
-        updateListItem(name, listId, itemId, userData, { description })
+        updateListItem(formattedName, listId, itemId, userData, { description })
       );
 
       return this.pendingPromise.promise

--- a/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
+++ b/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
@@ -132,7 +132,6 @@ class ListItemDescription extends PureComponent {
       match: {
         params: { id: listId }
       },
-      name,
       updateListItem
     } = this.props;
 

--- a/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
+++ b/client/src/modules/list/components/Items/ListItemDescription/ListItemDescription.jsx
@@ -8,17 +8,21 @@ import _flowRight from 'lodash/flowRight';
 import Linkify from 'react-linkify';
 import Textarea from 'react-textarea-autosize';
 import classNames from 'classnames';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 
 import Preloader, {
   PreloaderSize,
   PreloaderTheme
 } from 'common/components/Preloader';
-import { RouterMatchPropType, UserPropType } from 'common/constants/propTypes';
+import {
+  IntlPropType,
+  RouterMatchPropType,
+  UserPropType
+} from 'common/constants/propTypes';
 import { updateListItem } from '../model/actions';
 import { KeyCodes, NodeTypes } from 'common/constants/enums';
 import { AbortPromiseException } from 'common/exceptions/AbortPromiseException';
-import { makeAbortablePromise } from 'common/utils/helpers';
+import { formatName, makeAbortablePromise } from 'common/utils/helpers';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import './ListItemDescription.scss';
 
@@ -123,6 +127,7 @@ class ListItemDescription extends PureComponent {
     const {
       currentUser: { id: userId, name: userName },
       disabled,
+      intl: { formatMessage },
       itemId,
       match: {
         params: { id: listId }
@@ -138,7 +143,8 @@ class ListItemDescription extends PureComponent {
     if (isDescriptionUpdated) {
       this.setState({ pending: true });
 
-      const userData = { userId, editedBy: userName };
+      const formattedName = formatName(userName, formatMessage);
+      const userData = { userId, editedBy: formattedName };
 
       this.pendingPromise = makeAbortablePromise(
         updateListItem(name, listId, itemId, userData, { description })
@@ -301,6 +307,7 @@ ListItemDescription.propTypes = {
   currentUser: UserPropType.isRequired,
   description: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  intl: IntlPropType.isRequired,
   itemId: PropTypes.string.isRequired,
   locked: PropTypes.bool,
   match: RouterMatchPropType.isRequired,
@@ -316,6 +323,7 @@ const mapStateToProps = state => ({
 });
 
 export default _flowRight(
+  injectIntl,
   withRouter,
   connect(
     mapStateToProps,

--- a/client/src/modules/list/components/Items/ListItemName/ListItemName.jsx
+++ b/client/src/modules/list/components/Items/ListItemName/ListItemName.jsx
@@ -82,7 +82,7 @@ class ListItemName extends PureComponent {
       const userData = { userId, editedBy: formattedName };
 
       onPending();
-      updateListItem(name, listId, itemId, userData, {
+      updateListItem(formattedName, listId, itemId, userData, {
         name: updatedName
       }).finally(() => {
         this.setState({

--- a/client/src/modules/list/components/Items/ListItemName/ListItemName.jsx
+++ b/client/src/modules/list/components/Items/ListItemName/ListItemName.jsx
@@ -4,13 +4,19 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import _flowRight from 'lodash/flowRight';
+import { injectIntl } from 'react-intl';
 
 import { updateListItem } from '../model/actions';
-import { RouterMatchPropType, UserPropType } from 'common/constants/propTypes';
+import {
+  IntlPropType,
+  RouterMatchPropType,
+  UserPropType
+} from 'common/constants/propTypes';
 import { KeyCodes } from 'common/constants/enums';
 import Preloader from 'common/components/Preloader';
 import { getCurrentUser } from 'modules/user/model/selectors';
 import './ListItemName.scss';
+import { formatName } from 'common/utils/helpers';
 
 class ListItemName extends PureComponent {
   constructor(props) {
@@ -56,6 +62,7 @@ class ListItemName extends PureComponent {
     const { name: updatedName } = this.state;
     const {
       currentUser: { id: userId, name: userName },
+      intl: { formatMessage },
       itemId,
       match: {
         params: { id: listId }
@@ -71,7 +78,8 @@ class ListItemName extends PureComponent {
     if (canBeUpdated && isNameUpdated) {
       this.setState({ pending: true });
 
-      const userData = { userId, editedBy: userName };
+      const formattedName = formatName(userName, formatMessage);
+      const userData = { userId, editedBy: formattedName };
 
       onPending();
       updateListItem(name, listId, itemId, userData, {
@@ -174,6 +182,7 @@ class ListItemName extends PureComponent {
 
 ListItemName.propTypes = {
   currentUser: UserPropType.isRequired,
+  intl: IntlPropType.isRequired,
   isMember: PropTypes.bool.isRequired,
   itemId: PropTypes.string.isRequired,
   locked: PropTypes.bool,
@@ -191,6 +200,7 @@ const mapStateToProps = state => ({
 });
 
 export default _flowRight(
+  injectIntl,
   withRouter,
   connect(
     mapStateToProps,

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -37,7 +37,7 @@ import { ListType } from './consts';
 import { ResourceNotFoundException } from 'common/exceptions';
 import { joinRoom, leaveRoom } from 'common/model/actions';
 import history from 'common/utils/history';
-import { dashboardRoute } from 'common/utils/helpers';
+import { dashboardRoute, formatName } from 'common/utils/helpers';
 import './List.scss';
 
 class List extends Component {
@@ -316,6 +316,10 @@ class List extends Component {
       },
       { context: dialogContextMessage, name }
     );
+    const performerFormattedName = formatName(
+      externalAction.performer,
+      formatMessage
+    );
 
     return (
       <Fragment>
@@ -423,7 +427,7 @@ class List extends Component {
                   name,
                   cohortName,
                   context: dialogContextMessage,
-                  performer: externalAction.performer
+                  performer: performerFormattedName
                 }}
               />
               {!isOwner && (

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -225,14 +225,16 @@ class List extends Component {
   handleLeave = () => {
     const {
       currentUser: { id: currentUserId, name },
+      intl: { formatMessage },
       leaveList,
       list: { cohortId, type },
       match: {
         params: { id }
       }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
-    return leaveList(id, currentUserId, cohortId, name, type);
+    return leaveList(id, currentUserId, cohortId, formattedName, type);
   };
 
   renderBreadcrumbs = () => {

--- a/client/src/modules/list/index.jsx
+++ b/client/src/modules/list/index.jsx
@@ -318,10 +318,9 @@ class List extends Component {
       },
       { context: dialogContextMessage, name }
     );
-    const performerFormattedName = formatName(
-      externalAction.performer,
-      formatMessage
-    );
+    const performerFormattedName = externalAction
+      ? formatName(externalAction.performer, formatMessage)
+      : null;
 
     return (
       <Fragment>

--- a/client/src/modules/list/model/actions.js
+++ b/client/src/modules/list/model/actions.js
@@ -9,7 +9,7 @@ import { UserAddingStatus } from 'common/components/Members/const';
 import { ResourceNotFoundException } from 'common/exceptions';
 import socket from 'sockets';
 import { ListType } from 'modules/list/consts';
-import { cohortRoute, dashboardRoute, formatName } from 'common/utils/helpers';
+import { cohortRoute, dashboardRoute } from 'common/utils/helpers';
 
 const fetchListDataFailure = () => ({
   type: ListActionTypes.FETCH_DATA_FAILURE

--- a/client/src/modules/list/model/actions.js
+++ b/client/src/modules/list/model/actions.js
@@ -9,7 +9,7 @@ import { UserAddingStatus } from 'common/components/Members/const';
 import { ResourceNotFoundException } from 'common/exceptions';
 import socket from 'sockets';
 import { ListType } from 'modules/list/consts';
-import { cohortRoute, dashboardRoute } from 'common/utils/helpers';
+import { cohortRoute, dashboardRoute, formatName } from 'common/utils/helpers';
 
 const fetchListDataFailure = () => ({
   type: ListActionTypes.FETCH_DATA_FAILURE
@@ -429,7 +429,7 @@ export const removeListFromFavourites = (listId, name) => dispatch =>
       );
     });
 
-export const addListViewer = (listId, email) => dispatch =>
+export const addListViewer = (listId, email, formatMessage) => dispatch =>
   patchData(`/api/lists/${listId}/add-viewer`, {
     email
   })
@@ -437,11 +437,12 @@ export const addListViewer = (listId, email) => dispatch =>
     .then(viewer => {
       if (viewer._id) {
         const action = addViewerSuccess({ listId, viewer });
+        const formattedName = formatName(viewer.displayName, formatMessage);
 
         dispatch(action);
         createNotificationWithTimeout(dispatch, NotificationType.SUCCESS, {
           notificationId: 'list.actions.add-viewer',
-          data: { userName: viewer.displayName }
+          data: { userName: formattedName }
         });
 
         return UserAddingStatus.ADDED;

--- a/client/src/modules/list/model/actions.js
+++ b/client/src/modules/list/model/actions.js
@@ -429,7 +429,7 @@ export const removeListFromFavourites = (listId, name) => dispatch =>
       );
     });
 
-export const addListViewer = (listId, email, formatMessage) => dispatch =>
+export const addListViewer = (listId, email) => dispatch =>
   patchData(`/api/lists/${listId}/add-viewer`, {
     email
   })
@@ -437,12 +437,11 @@ export const addListViewer = (listId, email, formatMessage) => dispatch =>
     .then(viewer => {
       if (viewer._id) {
         const action = addViewerSuccess({ listId, viewer });
-        const formattedName = formatName(viewer.displayName, formatMessage);
 
         dispatch(action);
         createNotificationWithTimeout(dispatch, NotificationType.SUCCESS, {
           notificationId: 'list.actions.add-viewer',
-          data: { userName: formattedName }
+          data: { userName: viewer.displayName }
         });
 
         return UserAddingStatus.ADDED;

--- a/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
+++ b/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
@@ -10,6 +10,7 @@ import { getAccountDetails, updatePassword } from 'modules/user/model/actions';
 import ValidationInput from './ValidationInput';
 import PendingButton from 'common/components/PendingButton';
 import {
+  formatName,
   makeAbortablePromise,
   validatePassword,
   validateWith
@@ -56,6 +57,7 @@ class PasswordRecoveryForm extends PureComponent {
 
   fetchAccountData = () => {
     const {
+      intl: { formatMessage },
       match: {
         params: { token }
       }
@@ -65,9 +67,11 @@ class PasswordRecoveryForm extends PureComponent {
     this.pendingPromise = abortable;
 
     abortable.promise
-      .then(({ displayName, email }) =>
-        this.setState({ userName: displayName, email })
-      )
+      .then(({ displayName, email }) => {
+        const formattedName = formatName(displayName, formatMessage);
+
+        this.setState({ userName: formattedName, email });
+      })
       .catch(() => {
         /**
          * Ignore error

--- a/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
+++ b/client/src/modules/user/AuthBox/components/PasswordRecoveryForm.jsx
@@ -187,6 +187,7 @@ class PasswordRecoveryForm extends PureComponent {
     const {
       intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(userName, formatMessage);
 
     return (
       <form className="pass-recovery-form" onSubmit={this.handleSubmit}>
@@ -195,7 +196,10 @@ class PasswordRecoveryForm extends PureComponent {
           {userName ? (
             <FormattedMessage
               id="user.auth.pass-recovery-form.heading-user-name"
-              values={{ name: userName, email: <em title={email}>{email}</em> }}
+              values={{
+                name: formattedName,
+                email: <em title={email}>{email}</em>
+              }}
             />
           ) : (
             <FormattedMessage id="user.auth.pass-recovery-form.heading" />

--- a/client/src/modules/user/UserProfile/UserProfile.jsx
+++ b/client/src/modules/user/UserProfile/UserProfile.jsx
@@ -1,14 +1,20 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
+import {
+  injectIntl,
+  FormattedDate,
+  FormattedMessage,
+  FormattedTime
+} from 'react-intl';
 import classNames from 'classnames';
+import _flowRight from 'lodash/flowRight';
 
 import Avatar from 'common/components/Avatar';
 import { getCurrentUser } from 'modules/user/model/selectors';
-import { UserPropType } from 'common/constants/propTypes';
+import { IntlPropType, UserPropType } from 'common/constants/propTypes';
 import { AbortPromiseException } from 'common/exceptions/AbortPromiseException';
-import { makeAbortablePromise } from 'common/utils/helpers';
+import { formatName, makeAbortablePromise } from 'common/utils/helpers';
 import Preloader from 'common/components/Preloader';
 import { fetchUserDetails } from 'modules/user/model/actions';
 import PasswordChangeForm from 'modules/user/AuthBox/components/PasswordChangeForm';
@@ -56,8 +62,10 @@ class UserProfile extends PureComponent {
 
   renderPersonalInfo = () => {
     const {
-      currentUser: { avatarUrl, name }
+      currentUser: { avatarUrl, name },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
       <section className="user-profile__data-container">
@@ -73,7 +81,7 @@ class UserProfile extends PureComponent {
               <Avatar
                 avatarUrl={avatarUrl}
                 className="user-profile__avatar"
-                name={name}
+                name={formattedName}
               />
             </span>
           </li>
@@ -81,7 +89,7 @@ class UserProfile extends PureComponent {
             <span className="user-profile__data-name">
               <FormattedMessage id="user.name" />
             </span>
-            <span className="user-profile__data-value">{name}</span>
+            <span className="user-profile__data-value">{formattedName}</span>
           </li>
         </ul>
       </section>
@@ -186,13 +194,15 @@ class UserProfile extends PureComponent {
   render() {
     const { pending } = this.state;
     const {
-      currentUser: { avatarUrl, name }
+      currentUser: { avatarUrl, name },
+      intl: { formatMessage }
     } = this.props;
+    const formattedName = formatName(name, formatMessage);
 
     return (
       <div className="wrapper">
         <article className="user-profile">
-          <UserProfileHeader avatarUrl={avatarUrl} name={name} />
+          <UserProfileHeader avatarUrl={avatarUrl} name={formattedName} />
           {this.renderPersonalInfo()}
           {this.renderContactInfo()}
           {this.renderAccountInfo()}
@@ -205,6 +215,7 @@ class UserProfile extends PureComponent {
 
 UserProfile.propTypes = {
   currentUser: UserPropType.isRequired,
+  intl: IntlPropType.isRequired,
 
   fetchUserDetails: PropTypes.func.isRequired
 };
@@ -213,7 +224,10 @@ const mapStateToProps = state => ({
   currentUser: getCurrentUser(state)
 });
 
-export default connect(
-  mapStateToProps,
-  { fetchUserDetails }
+export default _flowRight(
+  injectIntl,
+  connect(
+    mapStateToProps,
+    { fetchUserDetails }
+  )
 )(UserProfile);

--- a/client/src/modules/user/UserProfile/UserProfileHeader.jsx
+++ b/client/src/modules/user/UserProfile/UserProfileHeader.jsx
@@ -1,25 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 
 import Avatar from 'common/components/Avatar';
 import './UserProfileHeader.scss';
+import { formatName } from 'common/utils/helpers';
+import { IntlPropType } from 'common/constants/propTypes';
 
-const UserProfileHeader = ({ avatarUrl, name }) => (
-  <h1 className="user-profile-header">
-    <span>
-      <Avatar
-        avatarUrl={avatarUrl}
-        className="user-profile-header__avatar"
-        name={name}
-      />
-    </span>
-    {name}
-  </h1>
-);
+const UserProfileHeader = ({ avatarUrl, intl: { formatMessage }, name }) => {
+  const formattedName = formatName(name, formatMessage);
+
+  return (
+    <h1 className="user-profile-header">
+      <span>
+        <Avatar
+          avatarUrl={avatarUrl}
+          className="user-profile-header__avatar"
+          name={formattedName}
+        />
+      </span>
+      {formattedName}
+    </h1>
+  );
+};
 
 UserProfileHeader.propTypes = {
   avatarUrl: PropTypes.string,
+  intl: IntlPropType.isRequired,
   name: PropTypes.string
 };
 
-export default UserProfileHeader;
+export default injectIntl(UserProfileHeader);


### PR DESCRIPTION
After a discussion with @Ciunkos  we decided to recognize if the user name is undefined, null or whatever only on front end and react to that by displaying the "Anonymous" string. 

The string has to be translated, that's why function formatName() takes formatMessage function from reac-intl library, as a second parameter. 