### PR TITLE
[EOC-539]  When the description for the sack or cohort is too long, all text is invisible

### DIFF
--- a/client/src/modules/cohort/components/CohortDescription.scss
+++ b/client/src/modules/cohort/components/CohortDescription.scss
@@ -10,6 +10,7 @@
     line-height: 1.2;
     color: $text-normal;
     padding: four-by(2) 0 four-by(4);
+    overflow-wrap: break-word;
 
     &--disabled {
       color: $gray-bg2;

--- a/client/src/modules/list/components/ListHeader.scss
+++ b/client/src/modules/list/components/ListHeader.scss
@@ -71,6 +71,7 @@
     line-height: 1.2;
     color: $text-normal;
     padding: four-by(2) 0 four-by(4);
+    overflow-wrap: break-word;
 
     &--disabled {
       color: $gray-bg2;


### PR DESCRIPTION
A `.mov` file showing how this issue is fixed tou can find in Jira EOC-539 task, under attachments sections.
https://jira2.sanddev.com/browse/EOC-539