### PR TITLE
[EOC-578] Disable access to redux via redux-developer-tools on production

### DIFF
--- a/client/src/app/model/store.js
+++ b/client/src/app/model/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
+import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import thunk from 'redux-thunk';
 
 import rootReducer from './reducer';

--- a/client/src/app/model/store.js
+++ b/client/src/app/model/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import thunk from 'redux-thunk';
 
 import rootReducer from './reducer';


### PR DESCRIPTION
To make this working we would have to set `'process.env.NODE_ENV': JSON.stringify('production')` webpack plugin but since v. 4 defining mode='production' makes it for us: [webpack docs](https://webpack.js.org/guides/production/#specify-the-environment).

Unfortunately, I couldn't test it locally because I was unable to run the production environment :-(

