### PR TITLE
[EOC-586] Fix safari bug related with new comment Textarea

### DIFF
--- a/client/src/common/components/Comments/CommentsList.jsx
+++ b/client/src/common/components/Comments/CommentsList.jsx
@@ -101,6 +101,7 @@ class CommentsList extends PureComponent {
           <NewComment
             onAddComment={this.handleAddComment}
             onClose={this.hideAddComment}
+            onClickOutside={this.hideAddComment}
           />
         )}
         <div className="comments__container">

--- a/client/src/common/components/Comments/NewComment.jsx
+++ b/client/src/common/components/Comments/NewComment.jsx
@@ -71,7 +71,8 @@ class NewComment extends PureComponent {
   render() {
     const { comment, pending } = this.state;
     const {
-      intl: { formatMessage }
+      intl: { formatMessage },
+      onClickOutside
     } = this.props;
 
     return (
@@ -80,6 +81,7 @@ class NewComment extends PureComponent {
           <Textarea
             disabled={pending}
             onChange={this.handleCommentChange}
+            onClickOutside={onClickOutside}
             placeholder={formatMessage({ id: 'common.add-comment' })}
           />
           {comment && (
@@ -108,6 +110,7 @@ NewComment.propTypes = {
   intl: IntlPropType.isRequired,
 
   onAddComment: PropTypes.func,
+  onClickOutside: PropTypes.func,
   onClose: PropTypes.func
 };
 

--- a/client/src/common/components/Forms/Textarea.jsx
+++ b/client/src/common/components/Forms/Textarea.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 import './Textarea.scss';
 
@@ -11,7 +10,6 @@ class Textarea extends PureComponent {
     const { initialValue } = this.props;
 
     this.state = {
-      isEnlarged: initialValue && initialValue.length > 0,
       value: initialValue || ''
     };
     this.textarea = React.createRef();
@@ -31,42 +29,18 @@ class Textarea extends PureComponent {
 
   focusTextarea = () => this.textarea.current.focus();
 
-  handleFocus = () => this.setState({ isEnlarged: true });
-
-  handleBlur = () => {
-    const { value } = this.state;
-
-    if (value.length === 0) {
-      this.setState({ isEnlarged: false });
-    }
-  };
-
   render() {
     const { disabled, placeholder } = this.props;
-    const { isEnlarged, value } = this.state;
+    const { value } = this.state;
 
     return (
       <div className="ss-textarea">
-        {placeholder && (
-          <button
-            className={classNames('ss-textarea__placeholder', {
-              'ss-textarea__placeholder--is-focused': isEnlarged
-            })}
-            disabled={isEnlarged}
-            onClick={this.focusTextarea}
-            type="button"
-          >
-            {placeholder}
-          </button>
-        )}
         <textarea
           className="ss-textarea__textarea"
           disabled={disabled}
           name={placeholder}
-          onBlur={this.handleBlur}
           onChange={this.handleOnChange}
-          onFocus={this.handleFocus}
-          placeholder={placeholder}
+          placeholder="Add comment"
           ref={this.textarea}
           value={value}
         />

--- a/client/src/common/components/Forms/Textarea.jsx
+++ b/client/src/common/components/Forms/Textarea.jsx
@@ -12,7 +12,16 @@ class Textarea extends PureComponent {
     this.state = {
       value: initialValue || ''
     };
+
     this.textarea = React.createRef();
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
   }
 
   handleOnChange = event => {
@@ -24,6 +33,17 @@ class Textarea extends PureComponent {
     this.setState({ value });
     if (onChange) {
       onChange(value);
+    }
+  };
+
+  handleClickOutside = event => {
+    const isClickedOutside = !this.textarea.current.contains(event.target);
+    const { onClickOutside } = this.props;
+    const { value } = this.state;
+    const isDirty = value.length > 0;
+
+    if (isClickedOutside && !isDirty) {
+      onClickOutside();
     }
   };
 
@@ -54,7 +74,8 @@ Textarea.propTypes = {
   initialValue: PropTypes.string,
   placeholder: PropTypes.string.isRequired,
 
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  onClickOutside: PropTypes.func
 };
 
 export default Textarea;

--- a/client/src/common/components/Forms/Textarea.jsx
+++ b/client/src/common/components/Forms/Textarea.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 
+import { IntlPropType } from 'common/constants/propTypes';
 import './Textarea.scss';
 
 class Textarea extends PureComponent {
@@ -50,7 +52,11 @@ class Textarea extends PureComponent {
   focusTextarea = () => this.textarea.current.focus();
 
   render() {
-    const { disabled, placeholder } = this.props;
+    const {
+      disabled,
+      intl: { formatMessage },
+      placeholder
+    } = this.props;
     const { value } = this.state;
 
     return (
@@ -60,7 +66,7 @@ class Textarea extends PureComponent {
           disabled={disabled}
           name={placeholder}
           onChange={this.handleOnChange}
-          placeholder="Add comment"
+          placeholder={formatMessage({ id: 'common.add-comment' })}
           ref={this.textarea}
           value={value}
         />
@@ -72,10 +78,11 @@ class Textarea extends PureComponent {
 Textarea.propTypes = {
   disabled: PropTypes.bool,
   initialValue: PropTypes.string,
+  intl: IntlPropType.isRequired,
   placeholder: PropTypes.string.isRequired,
 
   onChange: PropTypes.func,
   onClickOutside: PropTypes.func
 };
 
-export default Textarea;
+export default injectIntl(Textarea);

--- a/client/src/common/components/Forms/Textarea.scss
+++ b/client/src/common/components/Forms/Textarea.scss
@@ -8,18 +8,8 @@
     box-shadow: 0 0 0 2px rgba($border-focus, 0);
   }
 
-  &::before {
-    display: block;
-    content: '';
-    height: 20px;
-    background: $app-bg;
-    position: absolute;
-    left: 1px;
-    top: 1px;
-    right: 1px;
-  }
-
   &__textarea {
+    border-radius: 0;
     background-color: $bg-color;
     border: 1px solid $border-color;
     box-sizing: border-box;
@@ -30,37 +20,14 @@
     line-height: 1.2;
     min-height: 65px;
     outline: 0;
-    padding: four-by(4) four-by(2) four-by(2);
+    padding: four-by(2) four-by(2) four-by(2);
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     width: 100%;
     resize: none;
 
-    &::placeholder {
-      font-size: 0;
-    }
-
     &:focus {
       border: 1px solid rgba($border-focus, 0.54);
       box-shadow: 0 0 0 2px rgba($border-focus, 0);
-    }
-  }
-
-  &__placeholder {
-    position: absolute;
-    left: 12px;
-    top: 12px;
-    font-size: $s-font;
-    color: $text-normal;
-    font-family: 'Montserrat', sans-serif;
-    background: transparent;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    outline: 0;
-
-    &--is-focused {
-      font-size: 12px;
-      top: 5px;
     }
   }
 }


### PR DESCRIPTION
I needed to unify the comment field to use default placeholder cause safari treats ::before ::after elements placing differently and it was an issue with missing top border on iOS safari. 

![Zrzut ekranu 2019-10-31 o 08 43 29](https://user-images.githubusercontent.com/27632432/67928122-8a0b5c80-fbba-11e9-84af-d4e7a7f00903.png)
![Zrzut ekranu 2019-10-31 o 08 43 17](https://user-images.githubusercontent.com/27632432/67928123-8a0b5c80-fbba-11e9-9fa4-bd5fe7d0ae92.png)
