### PR TITLE
Topbar icons alignment hotfix

### DIFF
--- a/client/src/common/components/Activities/Activities.scss
+++ b/client/src/common/components/Activities/Activities.scss
@@ -18,7 +18,7 @@
     padding: 0 four-by(2) 2px;
 
     svg {
-      margin-top: 2px;
+      margin-top: 4px;
       height: 16px;
 
       path {


### PR DESCRIPTION
![iPhone_6s_Plus_—_12_2](https://user-images.githubusercontent.com/27632432/67928517-81675600-fbbb-11e9-8dd9-65910f543f9d.png)
