### PR TITLE
Fix description button styles on safari

### DIFF
--- a/client/src/app/styles/_buttons.scss
+++ b/client/src/app/styles/_buttons.scss
@@ -1,21 +1,22 @@
 .primary-button {
-  font-family: $font-family;
-  position: relative;
-  font-weight: 500;
-  color: $text-white;
-  font-size: $m-font;
-  text-transform: uppercase;
-  padding: four-by(2) four-by(4);
-  line-height: 1.2;
-  text-decoration: none;
-  display: block;
-  background: $button-bg;
-  border: 0;
-  min-height: 40px;
-  cursor: pointer;
-  width: auto;
-  outline: 0;
   -webkit-appearance: none;
+  background: $button-bg;
+  border-radius: 0;
+  border: 0;
+  color: $text-white;
+  cursor: pointer;
+  display: block;
+  font-family: $font-family;
+  font-size: $m-font;
+  font-weight: 500;
+  line-height: 1.2;
+  min-height: 40px;
+  outline: 0;
+  padding: four-by(2) four-by(4);
+  position: relative;
+  text-decoration: none;
+  text-transform: uppercase;
+  width: auto;
 
   &:disabled {
     cursor: not-allowed;

--- a/client/src/app/styles/_buttons.scss
+++ b/client/src/app/styles/_buttons.scss
@@ -10,6 +10,7 @@
   font-size: $m-font;
   font-weight: 500;
   line-height: 1.2;
+  margin: 0;
   min-height: 40px;
   outline: 0;
   padding: four-by(2) four-by(4);


### PR DESCRIPTION
We need to remember to always explicitly add border-radius: 0 when styling, cause Safari default behavior is to add some 3px border-radius 😵😵😵
**Before:**
![Zrzut ekranu 2019-11-11 o 09 02 32](https://user-images.githubusercontent.com/27632432/68571199-c4021b80-0462-11ea-851c-a8c16bd68820.png)

**After:**
![Zrzut ekranu 2019-11-11 o 09 05 32](https://user-images.githubusercontent.com/27632432/68571202-c5334880-0462-11ea-8fe6-f7d8f94c48b7.png)
