### PR TITLE
[EOC-626] MongoClient 'deprecated warning' in console

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,11 @@ const sessionStore = new MongoStore({
   mongooseConnection: mongoose.connection
 });
 
-mongoose.connect(dbUrl, { useNewUrlParser: true }, unlockLocks);
+mongoose.connect(
+  dbUrl,
+  { useNewUrlParser: true, useUnifiedTopology: true },
+  unlockLocks
+);
 mongoose.set('useCreateIndex', true);
 mongoose.set('useFindAndModify', false);
 


### PR DESCRIPTION
Because of :

![monogo](https://user-images.githubusercontent.com/25374390/68744697-7f5ab980-05f5-11ea-8163-be58dd9232ac.png)

I changed the MongoClient config according to [mongoose doc](https://mongoosejs.com/docs/deprecations.html)